### PR TITLE
Add base-level documentation for v2 themes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,195 @@
+# PokeLink Web Documentation
+
+Welcome to the comprehensive documentation for PokeLink Web - a collection of styled web sources for streamers to display their Pokémon teams in real-time.
+
+## Documentation Index
+
+### 📖 Core Documentation
+- **[Protocol Buffer Schema](protobuf-schema.md)** - Complete reference for V1 and V2 protobuf message types and schemas
+- **[Theme Data Structures](theme-data-structures.md)** - Available data types and interfaces for theme development
+- **[Data Reception & Events](data-reception-events.md)** - How themes receive and handle real-time data updates
+- **[Client API Reference](client-api-reference.md)** - Complete API reference for the PokeLink client
+- **[Build System](build-system.md)** - Complete guide to the Makefile and build process
+
+### 🎨 Development Guides
+- **[Theme Development Guide](theme-development-guide.md)** - Step-by-step guide for creating custom themes
+- **[Examples & Code Snippets](examples-and-snippets.md)** - Practical examples and reusable code snippets
+
+## Quick Start
+
+### For Theme Users
+1. Choose a theme from the `v2/themes/` directory
+2. Open the theme's `index.html` in a browser
+3. Add `?user=YourUsername` to the URL
+4. Use in OBS as a Browser Source
+
+### For Theme Developers
+1. Read the [Theme Development Guide](theme-development-guide.md)
+2. Understand the [Build System](build-system.md) for compilation and development workflows
+3. Explore [Examples & Code Snippets](examples-and-snippets.md)
+4. Reference the [Client API](client-api-reference.md) for available methods
+5. Use [Data Structures](theme-data-structures.md) for type information
+
+## Key Concepts
+
+### Protocol Versions
+- **V1 (Legacy)**: Socket.IO with JSON messages - found in root `themes/` directory
+- **V2 (Modern)**: WebSocket with Protocol Buffers - found in `v2/themes/` directory
+
+### Data Flow
+```
+PokeLink Server → WebSocket → Protocol Buffer → Event Emitter → Vue.js → DOM
+```
+
+### Event Types
+- **Party Updates**: When Pokemon party changes
+- **Badge Updates**: When gym badges are earned
+- **Death Events**: When Pokemon faint
+- **Revive Events**: When Pokemon are revived
+- **Graveyard Updates**: Complete fallen Pokemon list
+
+### Theme Structure
+```
+theme-name/
+├── assets/
+│   ├── css/styles.css     # Theme styling
+│   └── js/party.ts        # Main theme logic
+└── index.html             # Theme entry point
+```
+
+## Available Data
+
+### Pokemon Data
+Each Pokemon object contains:
+- **Core Info**: Species, level, Exp, HP
+- **Combat Data**: Moves, IVs, EVs, base stats, nature
+- **Metadata**: Nickname, gender, shiny status, held item
+- **Translations**: Names in multiple languages
+- **Sprites**: Multiple sprite sources with fallbacks
+
+### Real-time Events
+- Party composition changes
+- Individual Pokemon updates (HP, level, moves)
+- Badge/achievement progress
+- Pokemon deaths and revivals
+- Settings and sprite template updates
+
+## Development Tools
+
+### URL Parameters
+Control theme behavior via URL parameters:
+- `?user=Username` - Specify PokeLink username (required)
+- `?slot=1` - Show single Pokemon slot (1-6)
+- `?hp=true` - Display HP bars
+- `?debug=true` - Enable debug logging
+- `?template=URL` - Custom sprite template
+
+### Build System
+The project includes both Makefile and package.json scripts:
+
+```bash
+# Using Makefile (recommended)
+make setup              # Initial setup
+make dev               # Development with watch mode
+make build             # Complete build
+make help              # Show all available commands
+
+# Using yarn directly
+yarn install           # Install dependencies
+yarn build:core        # Build core libraries
+yarn build:themes      # Build themes
+yarn build             # Complete build
+```
+
+See [Build System Documentation](build-system.md) for complete details.
+
+### Testing
+- Use `?debug=true` for detailed event logging
+- Test with mock data using `?mock=true`
+- Verify across different browsers and screen sizes
+
+## Theme Categories
+
+### Party Display Themes
+Show current Pokemon party with various layouts:
+- **basic-card**: Clean card-based layout
+- **gameboy**: Retro GameBoy styling
+- **sword-shield-team**: Official game UI style
+
+### Badge Tracking Themes
+Display gym badge progress:
+- **default**: Simple badge grid
+- **badges-only**: Compact badge display
+
+### Death Counter Themes
+Track fallen Pokemon (for Nuzlocke runs):
+- **stick-it-down**: Memorial-style graveyard
+- **simple-circles**: Minimalist death counter
+
+### Specialty Themes
+Unique display formats:
+- **sports-game-scores**: Sports ticker style
+- **trozei**: Puzzle game inspired layout
+- **jezzabel-personal**: Sports ticker style
+
+## Best Practices
+
+### Performance
+- Use `v-memo` for expensive list items
+- Memoize computed properties
+- Preload sprites when possible
+- Clean up event listeners
+
+### Error Handling
+- Implement sprite fallbacks
+- Handle connection losses gracefully
+- Validate data before rendering
+- Provide user feedback for errors
+
+## Contributing
+
+### Creating New Themes
+1. Follow the [Theme Development Guide](theme-development-guide.md)
+2. Test thoroughly across different scenarios
+3. Add entry to `themes.json`
+4. Include preview image and documentation
+5. Submit pull request
+
+### Improving Documentation
+- Keep examples up-to-date
+- Add missing use cases
+- Improve clarity and organization
+- Test all code examples
+
+## Support
+
+### Common Issues
+- **Connection Failed**: Verify PokeLink server is running
+- **Sprites Not Loading**: Check internet connection and sprite URLs
+- **Theme Not Updating**: Clear browser cache and rebuild with `make rebuild`
+- **Build Errors**: Use `make clean` then `make setup`, or see [Build System](build-system.md) troubleshooting
+
+### Getting Help
+- Check existing GitHub issues
+- Review documentation thoroughly
+- Test with debug mode enabled
+- Provide detailed error descriptions
+
+## Version History
+
+### V2 (Current)
+- TypeScript support
+- Protocol Buffer messages
+- Enhanced sprite system
+- Comprehensive type safety
+- Modern Vue.js 3 architecture
+
+### V1 (Legacy)
+- JavaScript themes
+- Socket.IO communication
+- JSON message format
+- Basic Vue.js 2 support
+
+---
+
+*This documentation is continuously updated to reflect the latest PokeLink Web features and best practices.*

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -1,0 +1,456 @@
+# Build System Documentation
+
+This document provides comprehensive documentation for the PokeLink Web V2 build system, including the Makefile and package.json scripts.
+
+## Overview
+
+The PokeLink Web V2 build system is designed around:
+- **TypeScript compilation** for type safety
+- **Protocol Buffer generation** for efficient data serialization
+- **Webpack bundling** for optimized client libraries
+- **Modular builds** for themes, badges, and graveyards
+- **Development workflows** with watch mode support
+
+## Build Tools
+
+### Core Dependencies
+- **TypeScript**: Static type checking and ES2015+ to ES5 compilation
+- **Webpack**: Module bundling and asset optimization
+- **Protocol Buffers**: Efficient binary serialization format
+- **Vue.js**: Reactive framework for theme components
+- **Yarn**: Package management and script execution
+
+### Build Structure
+```
+v2/
+├── assets/              # Core library source
+│   ├── js/             # TypeScript source files
+│   ├── dist/           # Compiled output
+│   └── tsconfig.json   # TypeScript configuration
+├── themes/             # Theme sources
+│   ├── */assets/js/    # Individual theme TypeScript
+│   └── tsconfig.json   # Themes TypeScript config
+├── badges/             # Badge component sources
+├── graveyards/         # Graveyard component sources
+├── package.json        # Dependencies and npm scripts
+├── Makefile           # Make-based build system
+└── webpack.config.js  # Webpack configuration
+```
+
+## Using the Makefile
+
+The Makefile provides a more intuitive interface than raw npm/yarn scripts with colored output and better error handling.
+
+### Quick Reference
+
+```bash
+# Show all available commands
+make help
+
+# Initial setup
+make setup              # Install deps + generate protobuf
+
+# Development
+make dev               # Build core + watch for changes
+make build-watch       # Watch mode only
+
+# Building
+make build             # Complete build (prep + buf + compile all)
+make quick-build       # Fast build (skip prep/protobuf)
+make build-core        # Build only core libraries
+make build-themes      # Build only themes
+make build-badges      # Build only badges
+make build-graveyards  # Build only graveyards
+
+# Maintenance
+make clean             # Remove build artifacts
+make clean-deps        # Remove build artifacts + node_modules
+make rebuild           # Clean + build
+make check-types       # TypeScript type checking
+make validate          # Full validation
+```
+
+### Build Target Categories
+
+#### 🏗️ **Core Build Targets**
+
+##### `make build-core`
+Compiles the core TypeScript libraries and creates the webpack bundle.
+
+**What it does:**
+1. Compiles TypeScript from `assets/js/` to `assets/dist/`
+2. Bundles modules with webpack for browser consumption
+3. Generates source maps for debugging
+
+**Files processed:**
+- `assets/js/client.ts` → `assets/dist/client.js`
+- `assets/js/clientv2.ts` → `assets/dist/clientv2.js`
+- `assets/js/pokelink.ts` → `assets/dist/pokelink.js`
+- `assets/js/global.ts` → `assets/dist/global.js`
+
+**Output:**
+- JavaScript modules with type definitions
+- Source maps for debugging
+- Webpack bundles ready for browser import
+
+##### `make buf-generate`
+Generates TypeScript types from Protocol Buffer definitions.
+
+**What it does:**
+1. Reads `assets/proto/v2.proto`
+2. Generates TypeScript interfaces and classes
+3. Creates serialization/deserialization code
+
+**Output:**
+- `assets/js/v2_pb.js` - Generated protobuf code
+- Type definitions for all message types
+
+#### 🎨 **Component Build Targets**
+
+##### `make build-themes`
+Compiles all theme TypeScript files to JavaScript.
+
+**Process:**
+1. Scans `themes/*/assets/js/*.ts` files
+2. Compiles using `themes/tsconfig.json` configuration
+3. Outputs `.js` and `.js.map` files alongside source
+
+**Example:**
+```
+themes/basic-card/assets/js/party.ts
+  ↓ TypeScript compilation
+themes/basic-card/assets/js/party.js + party.js.map
+```
+
+##### `make build-badges`
+Compiles badge component TypeScript files.
+
+##### `make build-graveyards`  
+Compiles graveyard component TypeScript files.
+
+#### 🚀 **Development Targets**
+
+##### `make dev`
+Starts development mode with automatic rebuilding.
+
+**What it does:**
+1. Builds core libraries once
+2. Starts watch mode for all component types
+3. Automatically recompiles on file changes
+4. Runs multiple TypeScript watchers in parallel
+
+**Usage during development:**
+```bash
+make dev
+# Edit any .ts file
+# Watch console for compilation results
+# Refresh browser to see changes
+```
+
+##### `make build-watch`
+Watch mode only (no initial core build).
+
+**Parallel processes:**
+- `assets/` TypeScript watcher
+- `themes/` TypeScript watcher  
+- `badges/` TypeScript watcher
+- `graveyards/` TypeScript watcher
+
+#### 🧹 **Maintenance Targets**
+
+##### `make clean`
+Removes all compiled JavaScript files and source maps.
+
+**Files removed:**
+- `assets/dist/*`
+- `themes/*/assets/js/*.js`
+- `themes/*/assets/js/*.js.map`
+- `badges/*/assets/js/*.js`
+- `badges/*/assets/js/*.js.map`
+- `graveyards/*/assets/js/*.js`
+- `graveyards/*/assets/js/*.js.map`
+
+##### `make clean-deps`
+Complete cleanup including node_modules.
+
+**Use cases:**
+- Dependency corruption
+- Major version upgrades
+- Fresh development environment setup
+
+#### ✅ **Validation Targets**
+
+##### `make check-types`
+Type-checks all TypeScript without emitting files.
+
+**Validation scope:**
+- Core libraries type checking
+- Theme component type checking
+- Badge component type checking
+- Graveyard component type checking
+
+**Benefits:**
+- Fast type validation
+- No file output
+- Comprehensive error reporting
+- CI/CD integration ready
+
+##### `make validate`
+Complete project validation.
+
+**Current validation:**
+- TypeScript type checking
+- Extensible for future validations (linting, testing)
+
+### Complete Build Workflow
+
+#### Initial Setup
+```bash
+# First time setup
+make setup
+# Equivalent to: make prep + make buf-generate
+```
+
+#### Daily Development
+```bash
+# Start development
+make dev
+
+# In another terminal, make changes to themes
+# Files automatically recompile
+
+# When ready to test full build
+make quick-build
+```
+
+#### Production Deployment
+```bash
+# Clean build for production
+make clean
+make build-prod
+# Sets NODE_ENV=production for optimizations
+```
+
+#### Troubleshooting Build Issues
+```bash
+# Check for type errors
+make check-types
+
+# Nuclear option - rebuild everything
+make rebuild
+
+# Check build environment
+make info
+```
+
+## Package.json Scripts
+
+The original npm/yarn scripts are still available and form the foundation of the Makefile:
+
+### Core Scripts
+- `yarn prep` - Install dependencies
+- `yarn build:core` - Build core TypeScript + webpack
+- `yarn build:themes` - Build themes with dependencies
+- `yarn build:badges` - Build badges with dependencies  
+- `yarn build:graveyards` - Build graveyards with dependencies
+- `yarn build` - Complete build process
+
+### No-Dependency Scripts
+- `yarn build:themes:nodeps` - Build themes without rebuilding core
+- `yarn build:badges:nodeps` - Build badges without rebuilding core
+- `yarn build:graveyards:nodeps` - Build graveyards without rebuilding core
+
+### Buf (Protocol Buffers)
+- `yarn buf generate` - Generate TypeScript from .proto files
+
+## TypeScript Configuration
+
+### Shared Configuration
+Each module has its own `tsconfig.json` with shared base settings:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}
+```
+
+### Module-Specific Settings
+
+#### Assets (Core)
+- Outputs to `assets/dist/`
+- Includes webpack integration
+- Generates declaration files
+
+#### Themes
+- Preserves directory structure
+- Outputs alongside source files
+- Vue.js support enabled
+
+#### Badges & Graveyards  
+- Similar to themes configuration
+- Component-specific optimizations
+
+## Webpack Configuration
+
+### Bundle Strategy
+- **Entry points**: Multiple entry points for different modules
+- **Output**: AMD/UMD compatible modules
+- **Optimization**: Code splitting and tree shaking
+- **Development**: Source maps and hot reloading support
+
+### Loader Chain
+1. **TypeScript Loader**: `.ts` → JavaScript
+2. **Vue Loader**: `.vue` → JavaScript (if present)
+3. **Asset Loaders**: Images, fonts, CSS
+
+## Build Performance
+
+### Optimization Strategies
+
+#### Development
+- **Incremental compilation**: Only changed files
+- **Parallel builds**: Multiple TypeScript processes
+- **Source maps**: Full debugging information
+- **No minification**: Faster builds
+
+#### Production
+- **Tree shaking**: Remove unused code
+- **Minification**: Reduce bundle size
+- **Optimization**: Enable all webpack optimizations
+- **Source maps**: Production-safe source maps
+
+### Build Times
+Typical build times on modern hardware:
+
+| Target | Cold Build | Incremental |
+|--------|------------|-------------|
+| Core | ~10-15s | ~2-3s |
+| Themes | ~5-8s | ~1-2s |
+| Badges | ~2-3s | ~1s |
+| Graveyards | ~2-3s | ~1s |
+| **Full Build** | ~20-30s | ~5-8s |
+
+### Performance Tips
+
+#### For Development
+```bash
+# Use quick-build after initial setup
+make quick-build
+
+# Use component-specific builds
+make build-themes-only
+
+# Use watch mode for active development
+make dev
+```
+
+#### For CI/CD
+```bash
+# Parallel builds where possible
+make build-core &
+make buf-generate &
+wait
+make quick-build
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### Build Failures
+```bash
+# Check TypeScript errors
+make check-types
+
+# Verify dependencies
+make info
+
+# Clean rebuild
+make rebuild
+```
+
+#### Missing Dependencies
+```bash
+# Reinstall everything
+make clean-deps
+make setup
+```
+
+#### Protocol Buffer Issues  
+```bash
+# Regenerate protobuf types
+make buf-generate
+
+# Check if buf is installed
+yarn buf --version
+```
+
+#### Watch Mode Problems
+```bash
+# Stop all processes
+Ctrl+C
+
+# Restart development
+make dev
+```
+
+### Error Diagnosis
+
+#### TypeScript Compilation Errors
+- Check `tsconfig.json` settings
+- Verify import paths
+- Ensure all dependencies are installed
+
+#### Webpack Bundle Errors
+- Check `webpack.config.js`
+- Verify entry points exist
+- Check for circular dependencies
+
+#### Runtime Errors
+- Check browser console
+- Verify all scripts are loaded
+- Check for missing Protocol Buffer types
+
+## Integration with IDEs
+
+### VS Code
+Recommended extensions:
+- TypeScript and JavaScript Language Features
+- Vue Language Features (Volar)
+- Protocol Buffer support
+
+### WebStorm
+Built-in support for:
+- TypeScript compilation
+- Webpack integration
+- Vue.js development
+
+## Continuous Integration
+
+### GitHub Actions Example
+```yaml
+name: Build and Test
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+        cache: 'yarn'
+    - run: cd v2 && make setup
+    - run: cd v2 && make validate
+    - run: cd v2 && make build
+```
+
+This build system provides a robust foundation for developing PokeLink Web themes with modern tooling, type safety, and efficient development workflows.

--- a/docs/client-api-reference.md
+++ b/docs/client-api-reference.md
@@ -1,0 +1,534 @@
+# Client API Reference
+
+This document provides a complete reference for the PokeLink Web client API that theme developers use to interact with the PokeLink system.
+
+## Core API Namespace: `V2`
+
+The `V2` namespace contains all modern client functionality. Import it in your themes:
+
+```typescript
+import { V2, clientSettings, isDefined } from 'pokelink'
+```
+
+## Initialization
+
+### `V2.initialize(settings?: V2Settings)`
+
+Initializes the PokeLink client connection and starts listening for server events.
+
+**Parameters:**
+- `settings` (optional): Configuration object for client behavior
+
+**V2Settings Interface:**
+```typescript
+interface V2Settings {
+  numberOfPlayers?: number        // Number of players to track (-1 for all)
+  listenForSpriteUpdates?: boolean // Whether to update sprite templates dynamically
+}
+```
+
+**Default Values:**
+- `numberOfPlayers`: 1
+- `listenForSpriteUpdates`: true
+
+**Example:**
+```typescript
+// Basic initialization
+V2.initialize()
+
+// Advanced initialization
+V2.initialize({
+  numberOfPlayers: 2,              // Track 2 players
+  listenForSpriteUpdates: false    // Don't update sprites dynamically
+})
+```
+
+## Event Listeners
+
+### Party Events
+
+#### `V2.onPartyUpdate(handler: (party: (Pokemon | null)[], username: string) => void)`
+
+Registers a callback for party composition changes.
+
+**Parameters:**
+- `handler`: Function called when party updates
+  - `party`: Array of 6 Pokemon objects (null for empty slots)
+  - `username`: Username of the player whose party updated
+
+**Example:**
+```typescript
+V2.onPartyUpdate((party, username) => {
+  console.log(`${username}'s party updated:`)
+  
+  party.forEach((pokemon, index) => {
+    if (pokemon) {
+      console.log(`Slot ${index + 1}: ${pokemon.translations.english.speciesName}`)
+    }
+  })
+  
+  // Update Vue component
+  this.party = party
+})
+```
+
+### Badge Events
+
+#### `V2.onBadgeUpdate(handler: (badges: Badge[], username: string) => void)`
+
+Registers a callback for badge/achievement updates.
+
+**Parameters:**
+- `handler`: Function called when badges update
+  - `badges`: Array of Badge objects
+  - `username`: Username of the player
+
+**Example:**
+```typescript
+V2.onBadgeUpdate((badges, username) => {
+  const earned = badges.filter(b => b.obtained).length
+  console.log(`${username} has ${earned}/${badges.length} badges`)
+  
+  this.badges = badges
+})
+```
+
+### Death and Revival Events
+
+#### `V2.onDeath(handler: (pokemon: Pokemon, username: string) => void)`
+
+Registers a callback for Pokemon death events.
+
+**Example:**
+```typescript
+V2.onDeath((pokemon, username) => {
+  console.log(`💀 ${pokemon.translations.english.speciesName} fainted!`)
+  
+  // Add to graveyard with timestamp
+  this.graveyard.push({
+    ...pokemon,
+    deathTime: new Date()
+  })
+  
+  // Increment death counter
+  this.totalDeaths++
+})
+```
+
+#### `V2.onRevive(handler: (graveId: string, username: string) => void)`
+
+Registers a callback for Pokemon revival events.
+
+**Example:**
+```typescript
+V2.onRevive((graveId, username) => {
+  console.log(`✨ Pokemon with ID ${graveId} was revived!`)
+  
+  // Remove from graveyard
+  const index = this.graveyard.findIndex(p => p.graveyardMeta?.id === graveId)
+  if (index !== -1) {
+    this.graveyard.splice(index, 1)
+  }
+})
+```
+
+### Graveyard Events
+
+#### `V2.onGraveyardUpdate(handler: (graves: Pokemon[], username: string) => void)`
+
+Registers a callback for complete graveyard updates.
+
+**Example:**
+```typescript
+V2.onGraveyardUpdate((graves, username) => {
+  console.log(`Graveyard contains ${graves.length} fallen Pokemon`)
+  
+  // Sort by death time
+  this.graveyard = graves.sort((a, b) => {
+    const timeA = a.graveyardMeta?.timeOfDeath?.getTime() || 0
+    const timeB = b.graveyardMeta?.timeOfDeath?.getTime() || 0
+    return timeB - timeA
+  })
+})
+```
+
+### Connection Events
+
+#### `V2.onConnect(handler: () => void)`
+
+Registers a callback for successful server connections.
+
+**Example:**
+```typescript
+V2.onConnect(() => {
+  console.log('🔗 Connected to PokeLink server')
+  this.connected = true
+  this.showConnectionIndicator(true)
+})
+```
+
+### Sprite Events
+
+#### `V2.onSpriteTemplateUpdate(handler: () => void)`
+
+Registers a callback for sprite template changes.
+
+**Example:**
+```typescript
+V2.onSpriteTemplateUpdate(() => {
+  console.log('🎨 Sprite template updated')
+  // Force re-render of all Pokemon sprites
+  this.$forceUpdate()
+})
+```
+
+#### `V2.onSpriteSetReset(handler: () => void)`
+
+Registers a callback for sprite template resets.
+
+**Example:**
+```typescript
+V2.onSpriteSetReset(() => {
+  console.log('🔄 Sprite template reset to default')
+  this.$forceUpdate()
+})
+```
+
+## Sprite Management
+
+### `V2.getSprite(pokemon: Pokemon): string`
+
+Gets the primary sprite URL for a Pokemon.
+
+**Parameters:**
+- `pokemon`: Pokemon object
+
+**Returns:** String URL for the Pokemon sprite
+
+**Example:**
+```typescript
+const spriteUrl = V2.getSprite(pokemon)
+
+// Use in img tag
+<img :src="V2.getSprite(pokemon)" :alt="pokemon.translations.english.speciesName" />
+```
+
+### `V2.getPartySprite(pokemon: Pokemon): string`
+
+Gets the party-optimized sprite URL for a Pokemon (usually smaller/simpler).
+
+**Example:**
+```typescript
+const partySprite = V2.getPartySprite(pokemon)
+
+// Use for compact party display
+<img :src="V2.getPartySprite(pokemon)" class="party-sprite" />
+```
+
+### `V2.useFallback(img: HTMLImageElement, pokemon: Pokemon)`
+
+Switches an image element to the fallback sprite when the primary fails to load.
+
+**Parameters:**
+- `img`: HTML image element that failed to load
+- `pokemon`: Pokemon object containing fallback URL
+
+**Example:**
+```typescript
+// In Vue template
+<img :src="V2.getSprite(pokemon)" 
+     @error="V2.useFallback($event.target, pokemon)"
+     :alt="pokemon.translations.english.speciesName" />
+
+// Or in component method
+methods: {
+  handleSpriteError(event) {
+    V2.useFallback(event.target, this.pokemon)
+  }
+}
+```
+
+### `V2.usePartyFallback(img: HTMLImageElement, pokemon: Pokemon)`
+
+Similar to `useFallback` but for party sprites.
+
+## Utility Functions
+
+### `V2.isValidPokemon(pokemon: Pokemon | null): boolean`
+
+Checks if a Pokemon object is valid and not null.
+
+**Example:**
+```typescript
+const validPokemon = this.party.filter(V2.isValidPokemon)
+
+// Or in template
+<div v-for="pokemon in party" v-if="V2.isValidPokemon(pokemon)">
+  <!-- Pokemon display -->
+</div>
+```
+
+### `V2.getTypeColor(englishType: string): string`
+
+Gets the official color for a Pokemon type.
+
+**Parameters:**
+- `englishType`: English name of the type (e.g., "Fire", "Water")
+
+**Returns:** Hex color string
+
+**Example:**
+```typescript
+const fireColor = V2.getTypeColor('Fire') // '#f08030'
+
+// Use in styling
+<span :style="{ backgroundColor: V2.getTypeColor(type) }">
+  {{ type }}
+</span>
+```
+
+### `V2.getStatusColor(englishStatus: string): string`
+
+Gets the color for a status condition.
+
+**Example:**
+```typescript
+const poisonColor = V2.getStatusColor('Poisoned') // '#c060c0'
+```
+
+### `V2.updateSpriteTemplate(template: string | null)`
+
+Manually updates the sprite template (usually handled automatically).
+
+**Parameters:**
+- `template`: Handlebars template string or null to reset
+
+## Client Settings
+
+### `clientSettings` Object
+
+Global configuration object available to themes:
+
+```typescript
+interface ClientSettings {
+  debug: boolean                        // Debug mode enabled
+  params: ParamsManager                 // URL parameter manager
+  host: string                          // Server hostname
+  port: number                          // Server port
+  users: string[]                       // Tracked usernames
+  useFallbackSprites: boolean          // Force use of fallback sprites
+  spriteTemplate: HandlebarsTemplateDelegate    // Compiled sprite template
+  itemSpriteTemplate: HandlebarsTemplateDelegate // Compiled item template
+}
+```
+
+**Example Usage:**
+```typescript
+// Check if debug mode is enabled
+if (clientSettings.debug) {
+  console.log('Debug information:', data)
+}
+
+// Get sprite URL using template
+const spriteUrl = clientSettings.spriteTemplate(pokemon)
+
+// Get item sprite URL
+const itemUrl = clientSettings.itemSpriteTemplate(pokemon)
+```
+
+### `ParamsManager` Methods
+
+Access URL parameters in themes:
+
+#### `clientSettings.params.hasKey(key: string): boolean`
+
+Check if a URL parameter exists.
+
+#### `clientSettings.params.getString(key: string, default?: string): string | undefined`
+
+Get string parameter value.
+
+#### `clientSettings.params.getBool(key: string, default: boolean = false): boolean`
+
+Get boolean parameter value ('true'/'false' strings).
+
+#### `clientSettings.params.getNumber(key: string, default: number = 1): number`
+
+Get numeric parameter value.
+
+**Example:**
+```typescript
+// URL: theme.html?user=Player1&slot=3&hp=true&debug=false
+
+const username = clientSettings.params.getString('user', 'DefaultUser')  // 'Player1'
+const slotNumber = clientSettings.params.getNumber('slot', 1)            // 3
+const showHP = clientSettings.params.getBool('hp', false)               // true
+const debugMode = clientSettings.params.getBool('debug', false)         // false
+
+// Use in theme logic
+if (clientSettings.params.hasKey('slot')) {
+  // Show only specific slot
+  this.singleSlotMode = true
+  this.targetSlot = slotNumber
+}
+```
+
+## Utility Exports
+
+### `isDefined<T>(value: T | null | undefined): value is T`
+
+Type-safe check for defined values.
+
+**Example:**
+```typescript
+if (isDefined(pokemon.nickname)) {
+  // TypeScript knows pokemon.nickname is definitely a string here
+  displayName = pokemon.nickname.toUpperCase()
+}
+```
+
+### `string2ColHex(input: string): string`
+
+Generate consistent hex color from string.
+
+**Example:**
+```typescript
+const pokemonColor = string2ColHex(pokemon.translations.english.speciesName)
+// Same Pokemon species always generates the same color
+```
+
+### `hex2rgba(hex: string, opacity: number): string`
+
+Convert hex color to RGBA with opacity.
+
+**Example:**
+```typescript
+const semiTransparentRed = hex2rgba('#ff0000', 50) // 'rgba(255,0,0,0.5)'
+```
+
+### `resolveIllegalCharacters(input: string): string`
+
+Clean string for use in URLs (removes illegal characters).
+
+**Example:**
+```typescript
+const cleanName = resolveIllegalCharacters("Pokémon?!")  // "Pokémon"
+```
+
+## Data Type Exports
+
+### `V2DataTypes`
+
+All Protocol Buffer types for advanced usage:
+
+```typescript
+import { V2DataTypes } from 'pokelink'
+
+// Access specific types
+const pokemon: V2DataTypes.Pokemon = /* ... */
+const badge: V2DataTypes.Badge = /* ... */
+const gender: V2DataTypes.Gender = V2DataTypes.Gender.male
+```
+
+### `Nullable<T>`
+
+Type alias for values that can be null or undefined:
+
+```typescript
+type Nullable<T> = T | null | undefined
+
+// Usage
+const maybeString: Nullable<string> = pokemon.nickname
+```
+
+## Color Constants
+
+### `typeColors`
+
+Object mapping Pokemon types to their official colors:
+
+```typescript
+const typeColors = {
+  'Fire': '#f08030',
+  'Water': '#6890f0',
+  'Grass': '#78c850',
+  // ... all 18 types
+}
+```
+
+### `statusColors`
+
+Object mapping status conditions to colors:
+
+```typescript
+const statusColors = {
+  'Poisoned': '#c060c0',
+  'Paralyzed': '#b8b818',
+  'Asleep': '#a0a088',
+  'Frozen': '#88b0e0',
+  'Burned': '#e07050',
+  'Fainted': '#e85038'
+}
+```
+
+### `htmlColors`
+
+Complete mapping of HTML color names to hex values.
+
+## Handlebars Integration
+
+### Custom Helpers
+
+PokeLink registers custom Handlebars helpers for sprite templates:
+
+- `isDefined(value)`: Check if value is defined
+- `ifElse(condition, ifTrue, ifFalse)`: Ternary operator
+- `concat(str1, str2)`: String concatenation
+- `toLower(str)`: Convert to lowercase
+- `noSpaces(str)`: Remove all spaces
+- `underscoreSpaces(str)`: Replace spaces with underscores
+- `remove(str, filter)`: Remove substring
+- `nidoranGender(str, maleTag, femaleTag)`: Handle Nidoran gender variants
+- `addFemaleTag(pokemon, tag)`: Add tag for female Pokemon
+- `isZero(value)`: Check if number is zero
+
+**Example Template:**
+```handlebars
+https://example.com/sprites/{{toLower (noSpaces translations.english.speciesName)}}{{addFemaleTag this "-f"}}{{ifElse isShiny "-shiny" ""}}.png
+```
+
+## Error Handling
+
+### Connection Errors
+
+```typescript
+// Listen for disconnections
+client.events.once('disconnected', () => {
+  console.log('Connection lost, attempting reconnection...')
+  this.connected = false
+})
+
+// Handle parsing errors
+client.events.on('parseError', (error, rawData) => {
+  console.error('Failed to parse server data:', error)
+})
+```
+
+### Sprite Loading Errors
+
+```typescript
+// Automatic fallback handling
+<img :src="V2.getSprite(pokemon)" 
+     @error="V2.useFallback($event.target, pokemon)"
+     :alt="pokemon.translations.english.speciesName" />
+
+// Manual error handling
+methods: {
+  handleImageError(event, pokemon) {
+    console.log(`Sprite failed to load for ${pokemon.translations.english.speciesName}`)
+    V2.useFallback(event.target, pokemon)
+  }
+}
+```
+
+This API provides everything needed to create robust, interactive PokeLink themes with real-time data updates and comprehensive error handling.

--- a/docs/data-reception-events.md
+++ b/docs/data-reception-events.md
@@ -1,0 +1,457 @@
+# Data Reception and Event Handling
+
+This document explains how themes receive and handle real-time data updates from the PokeLink server.
+
+## Overview
+
+PokeLink Web uses an event-driven architecture where the client establishes a WebSocket connection to receive real-time updates. Data flows through the following pipeline:
+
+```
+PokeLink Server → WebSocket → Protocol Buffer Decoder → Event Emitter → Vue Components → DOM Updates
+```
+
+## Connection Management
+
+### Automatic Connection Handling
+
+The PokeLink client automatically manages connections with built-in reconnection logic:
+
+```typescript
+// Connection is established automatically when initializing
+V2.initialize({
+  numberOfPlayers: 1,              // How many players to track
+  listenForSpriteUpdates: true     // Whether to update sprites dynamically
+})
+
+// Listen for connection events
+V2.onConnect(() => {
+  console.log('Connected to PokeLink server')
+  // Show connection indicator, enable UI, etc.
+})
+
+// Disconnection is handled automatically with reconnection attempts
+client.events.once('disconnected', () => {
+  console.log('Disconnected from server, attempting reconnection...')
+  // Show disconnection overlay, disable animations, etc.
+})
+```
+
+### Connection States
+
+Themes should handle different connection states:
+
+```typescript
+export default {
+  data() {
+    return {
+      connected: false,
+      loaded: false,    // Has received initial data
+      party: []
+    }
+  },
+  
+  mounted() {
+    V2.onConnect(() => {
+      this.connected = true
+    })
+    
+    // First party update indicates data is loaded
+    V2.onPartyUpdate((party) => {
+      this.party = party
+      this.loaded = true
+    })
+  }
+}
+```
+
+## Event Channels
+
+### Core Event Types
+
+PokeLink emits several types of events that themes can listen to:
+
+#### 1. Party Updates (`client:party:updated`)
+Fired when Pokemon party composition or stats change:
+
+```typescript
+V2.onPartyUpdate((party: (Pokemon | null)[], username: string) => {
+  console.log(`Party update for ${username}:`)
+  
+  party.forEach((pokemon, index) => {
+    if (pokemon) {
+      console.log(`Slot ${index + 1}: ${pokemon.translations.english.speciesName} (Level ${pokemon.level})`)
+      console.log(`  HP: ${pokemon.hp.current}/${pokemon.hp.max}`)
+      console.log(`  Status: ${pokemon.translations.english.status}`)
+    } else {
+      console.log(`Slot ${index + 1}: Empty`)
+    }
+  })
+  
+  // Update theme state
+  this.party = party
+})
+```
+
+#### 2. Badge Updates (`client:badges:updated`) 
+Fired when gym badges or achievements are earned:
+
+```typescript
+V2.onBadgeUpdate((badges: Badge[], username: string) => {
+  console.log(`Badge update for ${username}:`)
+  
+  const earnedBadges = badges.filter(badge => badge.obtained)
+  console.log(`Badges earned: ${earnedBadges.length}/${badges.length}`)
+  
+  // Update badge display
+  this.badges = badges
+  
+  // Play animation for newly earned badges
+  const newBadges = badges.filter(badge => 
+    badge.obtained && !this.previousBadges.some(prev => prev.id === badge.id && prev.obtained)
+  )
+  
+  newBadges.forEach(badge => {
+    this.playBadgeEarnedAnimation(badge)
+  })
+})
+```
+
+#### 3. Death Events (`client:party:death`)
+Fired when a Pokemon faints:
+
+```typescript
+V2.onDeath((pokemon: Pokemon, username: string) => {
+  console.log(`${pokemon.translations.english.speciesName} fainted!`)
+  
+  // Add to graveyard
+  this.graveyard.push(pokemon)
+  
+  // Play death animation
+  this.playDeathAnimation(pokemon)
+  
+  // Update death counter
+  this.deathCount++
+  
+  // Show memorial notification
+  this.showMemorialNotification(pokemon)
+})
+```
+
+#### 4. Revive Events (`client:party:revive`)
+Fired when a Pokemon is revived from the graveyard:
+
+```typescript
+V2.onRevive((graveId: string, username: string) => {
+  console.log(`Pokemon with grave ID ${graveId} was revived`)
+  
+  // Find and remove from graveyard
+  const revivedIndex = this.graveyard.findIndex(pokemon => 
+    pokemon.graveyardMeta?.id === graveId
+  )
+  
+  if (revivedIndex !== -1) {
+    const revivedPokemon = this.graveyard.splice(revivedIndex, 1)[0]
+    this.playReviveAnimation(revivedPokemon)
+  }
+})
+```
+
+#### 5. Graveyard Updates (`client:graveyard:updated`)
+Fired when the complete graveyard contents change:
+
+```typescript
+V2.onGraveyardUpdate((graves: Pokemon[], username: string) => {
+  console.log(`Graveyard update: ${graves.length} fallen Pokemon`)
+  
+  // Update graveyard display
+  this.graveyard = graves
+  
+  // Sort by death time (most recent first)
+  this.graveyard.sort((a, b) => {
+    const timeA = a.graveyardMeta?.timeOfDeath?.getTime() || 0
+    const timeB = b.graveyardMeta?.timeOfDeath?.getTime() || 0
+    return timeB - timeA
+  })
+})
+```
+
+### Advanced Event Handling
+
+#### Event Filtering by Username
+
+For multi-user environments, filter events by username:
+
+```typescript
+const targetUsers = ['Player1', 'Player2'] // From URL parameters
+
+V2.onPartyUpdate((party, username) => {
+  if (!targetUsers.includes(username)) {
+    return // Ignore updates for other users
+  }
+  
+  // Process update for tracked user
+  this.updatePartyForUser(username, party)
+})
+```
+
+#### Debounced Updates
+
+For performance, debounce rapid updates:
+
+```typescript
+import { debounce } from 'lodash'
+
+const debouncedPartyUpdate = debounce((party) => {
+  this.party = party
+  this.$forceUpdate()
+}, 100) // Update at most once per 100ms
+
+V2.onPartyUpdate((party) => {
+  debouncedPartyUpdate(party)
+})
+```
+
+#### Event Chaining
+
+Handle related events together:
+
+```typescript
+// Track recent deaths for memorial display
+const recentDeaths = []
+
+V2.onDeath((pokemon) => {
+  recentDeaths.push({
+    pokemon,
+    timestamp: Date.now()
+  })
+  
+  // Remove deaths older than 5 minutes
+  const fiveMinutesAgo = Date.now() - (5 * 60 * 1000)
+  recentDeaths.splice(0, recentDeaths.findIndex(death => death.timestamp > fiveMinutesAgo))
+})
+
+V2.onPartyUpdate((party) => {
+  // Check if any previously alive Pokemon are now missing (indicating death)
+  const currentAlive = party.filter(p => p !== null).map(p => p.pid)
+  const previousAlive = this.previousParty.filter(p => p !== null).map(p => p.pid)
+  
+  const newlyMissing = previousAlive.filter(pid => !currentAlive.includes(pid))
+  // Handle newly missing Pokemon...
+})
+```
+
+## Data Transformation Pipeline
+
+### Protocol Buffer Decoding
+
+Data flows through several transformation layers:
+
+```typescript
+// 1. Raw Protocol Buffer bytes received via WebSocket
+const rawBuffer: Uint8Array = /* received from server */
+
+// 2. Decoded to typed message objects
+const partyMessage = fromBinary(PartySchema, rawBuffer)
+
+// 3. Transformed to theme-friendly format
+const party: (Pokemon | null)[] = partyMessage.party.map(slot => slot.pokemon)
+
+// 4. Emitted as typed events
+events.emit('client:party:updated', party, partyMessage.username)
+
+// 5. Handled by theme event listeners
+V2.onPartyUpdate((party, username) => {
+  // Theme receives clean, typed data
+})
+```
+
+### Data Validation
+
+All received data is automatically validated:
+
+```typescript
+// Type validation through TypeScript
+V2.onPartyUpdate((party: (Pokemon | null)[], username: string) => {
+  party.forEach((pokemon, index) => {
+    if (pokemon) {
+      // TypeScript guarantees these fields exist and are the correct type
+      const species: number = pokemon.species        // Always a number
+      const level: number = pokemon.level           // Always a number  
+      const hp: HP = pokemon.hp                     // Always has max/current
+      
+      // Optional fields are properly typed
+      const nickname: string | undefined = pokemon.nickname
+      const isShiny: boolean | undefined = pokemon.isShiny
+      
+      // Use type guards for safety
+      if (pokemon.nickname) {
+        console.log(`Nickname: ${pokemon.nickname}`) // TypeScript knows it's defined
+      }
+    }
+  })
+})
+```
+
+### Error Handling
+
+Robust error handling for network issues:
+
+```typescript
+// Connection error handling
+client.events.on('error', (error) => {
+  console.error('Connection error:', error)
+  // Show error message to user
+  this.showConnectionError()
+})
+
+// Data parsing error handling  
+client.events.on('parseError', (error, rawData) => {
+  console.error('Failed to parse server data:', error)
+  // Log for debugging but don't crash the theme
+})
+
+// Sprite loading error handling
+V2.onPartyUpdate((party) => {
+  party.forEach(pokemon => {
+    if (pokemon) {
+      // Sprites have fallback mechanisms built-in
+      const sprite = V2.getSprite(pokemon) // Automatically handles fallbacks
+    }
+  })
+})
+```
+
+## Performance Optimization
+
+### Efficient Event Handling
+
+```typescript
+// Use computed properties instead of watchers when possible
+export default {
+  computed: {
+    // Automatically updates when party changes
+    alivePokemon(): Pokemon[] {
+      return this.party.filter(p => p !== null) as Pokemon[]
+    },
+    
+    // Cached calculation
+    averageLevel(): number {
+      const alive = this.alivePokemon
+      if (alive.length === 0) return 0
+      
+      return alive.reduce((sum, p) => sum + p.level, 0) / alive.length
+    }
+  },
+  
+  methods: {
+    // Efficient party updates
+    updateParty(newParty: (Pokemon | null)[]) {
+      // Only update if actually changed
+      if (this.partiesEqual(this.party, newParty)) {
+        return
+      }
+      
+      // Batch DOM updates
+      this.$nextTick(() => {
+        this.party = newParty
+      })
+    },
+    
+    partiesEqual(a: (Pokemon | null)[], b: (Pokemon | null)[]): boolean {
+      if (a.length !== b.length) return false
+      
+      return a.every((pokemon, index) => {
+        const other = b[index]
+        if (!pokemon && !other) return true
+        if (!pokemon || !other) return false
+        
+        // Compare by PID for identity
+        return pokemon.pid === other.pid
+      })
+    }
+  }
+}
+```
+
+### Memory Management
+
+```typescript
+// Clean up event listeners when theme is destroyed
+export default {
+  beforeUnmount() {
+    // Events are automatically cleaned up, but you can manually remove them
+    events.removeAllListeners('client:party:updated')
+    events.removeAllListeners('client:badges:updated')
+  },
+  
+  methods: {
+    // Limit graveyard size to prevent memory leaks
+    addToGraveyard(pokemon: Pokemon) {
+      this.graveyard.push(pokemon)
+      
+      // Keep only last 100 deaths
+      if (this.graveyard.length > 100) {
+        this.graveyard.splice(0, this.graveyard.length - 100)
+      }
+    }
+  }
+}
+```
+
+## Testing and Development
+
+### Debug Mode
+
+Enable debug mode for detailed event logging:
+
+```typescript
+// Add ?debug=true to theme URL
+// Or set in initialization
+V2.initialize({
+  debug: true // Enables detailed console logging
+})
+
+// Debug mode logs all events:
+// "Party update: [Pokemon data...]"
+// "Badge update: [Badge data...]" 
+// "Death update: [Pokemon data...]"
+```
+
+### Mock Data for Development
+
+Test themes with mock data:
+
+```typescript
+// Create test data for development
+const mockParty: (Pokemon | null)[] = [
+  {
+    pid: 123456,
+    species: 6, // Charizard
+    level: 50,
+    hp: { max: 150, current: 120 },
+    translations: {
+      english: { speciesName: 'Charizard', status: 'Healthy', types: ['Fire', 'Flying'] },
+      locale: { speciesName: 'Charizard', status: 'Healthy', types: ['Fire', 'Flying'] }
+    },
+    // ... other required fields
+  },
+  null, // Empty slot
+  null,
+  null,
+  null,
+  null
+]
+
+// In development mode, use mock data
+if (process.env.NODE_ENV === 'development') {
+  setTimeout(() => {
+    this.party = mockParty
+  }, 1000)
+} else {
+  V2.onPartyUpdate((party) => {
+    this.party = party
+  })
+}
+```
+
+This event-driven architecture ensures themes receive real-time updates while maintaining type safety and performance. The automatic reconnection and error handling provide a robust foundation for streaming applications.

--- a/docs/examples-and-snippets.md
+++ b/docs/examples-and-snippets.md
@@ -1,0 +1,888 @@
+# Examples and Code Snippets
+
+This document provides practical code examples and reusable snippets for common PokeLink theme development scenarios.
+
+## Basic Theme Examples
+
+### Minimal Single-Slot Theme
+
+A simple theme that displays just one Pokemon slot:
+
+```typescript
+// party.ts
+import { createApp } from 'vue'
+import { V2, clientSettings } from 'pokelink'
+import type { Pokemon } from 'v2Proto'
+
+createApp({
+    data() {
+        return {
+            pokemon: null as Pokemon | null,
+            loaded: false
+        }
+    },
+    
+    mounted() {
+        V2.initialize()
+        
+        const slotNumber = clientSettings.params.getNumber('slot', 1)
+        
+        V2.onPartyUpdate((party) => {
+            this.pokemon = party[slotNumber - 1] || null
+            this.loaded = true
+        })
+    }
+}).mount('#app')
+```
+
+```html
+<!-- index.html -->
+<div id="app" v-show="loaded">
+    <div v-if="pokemon" class="pokemon-display">
+        <img :src="getSprite(pokemon)" class="sprite" />
+        <h2>{{ pokemon.nickname || pokemon.translations.english.speciesName }}</h2>
+        <div class="level">Level {{ pokemon.level }}</div>
+    </div>
+    <div v-else class="empty-slot">No Pokemon in this slot</div>
+</div>
+```
+
+### Team Overview Theme
+
+Display all 6 party slots with key information:
+
+```typescript
+// party.ts
+createApp({
+    data() {
+        return {
+            party: [] as (Pokemon | null)[],
+            connected: false,
+            loaded: false
+        }
+    },
+    
+    mounted() {
+        V2.initialize()
+        
+        V2.onPartyUpdate((party) => {
+            this.party = party
+            this.loaded = true
+        })
+        
+        V2.onConnect(() => {
+            this.connected = true
+        })
+    },
+    
+    computed: {
+        teamStats() {
+            const alive = this.party.filter(p => p !== null)
+            const totalLevel = alive.reduce((sum, p) => sum + p!.level, 0)
+            
+            return {
+                count: alive.length,
+                totalLevel,
+                averageLevel: alive.length > 0 ? Math.round(totalLevel / alive.length) : 0
+            }
+        }
+    }
+}).mount('#party')
+```
+
+```html
+<!-- Team overview template -->
+<div id="party" class="team-overview">
+    <div class="team-stats" v-if="loaded">
+        <span>{{ teamStats.count }}/6 Pokemon</span>
+        <span>Avg Level: {{ teamStats.averageLevel }}</span>
+    </div>
+    
+    <div class="pokemon-grid">
+        <div v-for="(pokemon, index) in party" 
+             :key="pokemon?.pid || index" 
+             class="slot"
+             :class="{ empty: !pokemon }">
+            
+            <template v-if="pokemon">
+                <img :src="getSprite(pokemon)" />
+                <div class="info">
+                    <span class="name">{{ pokemon.nickname || pokemon.translations.english.speciesName }}</span>
+                    <span class="level">Lv.{{ pokemon.level }}</span>
+                </div>
+            </template>
+            
+            <div v-else class="empty-indicator">Empty</div>
+        </div>
+    </div>
+</div>
+```
+
+## Advanced Component Examples
+
+### Reusable Health Bar Component
+
+```typescript
+// components/health-bar.vue.ts
+import { defineComponent, PropType } from 'vue'
+import type { Pokemon, HP } from 'v2Proto'
+
+export default defineComponent({
+    template: `
+        <div class="health-bar-container">
+            <div class="health-bar" :class="healthClass">
+                <div class="health-fill" 
+                     :style="{ width: healthPercent + '%' }"
+                     :class="healthClass">
+                </div>
+            </div>
+            <div class="health-text" v-if="showText">
+                {{ hp.current }} / {{ hp.max }}
+            </div>
+        </div>
+    `,
+    
+    props: {
+        hp: {
+            type: Object as PropType<HP>,
+            required: true
+        },
+        showText: {
+            type: Boolean,
+            default: true
+        },
+        animated: {
+            type: Boolean,
+            default: true
+        }
+    },
+    
+    computed: {
+        healthPercent(): number {
+            if (this.hp.max === 0) return 0
+            return Math.round((this.hp.current / this.hp.max) * 100)
+        },
+        
+        healthClass(): string {
+            if (this.healthPercent <= 10) return 'critical'
+            if (this.healthPercent <= 25) return 'low'
+            if (this.healthPercent <= 50) return 'medium'
+            return 'healthy'
+        }
+    }
+})
+```
+
+```css
+/* health-bar styles */
+.health-bar-container {
+    width: 100%;
+}
+
+.health-bar {
+    width: 100%;
+    height: 20px;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 10px;
+    overflow: hidden;
+    position: relative;
+}
+
+.health-fill {
+    height: 100%;
+    transition: width 1s ease;
+    border-radius: 10px;
+}
+
+.health-fill.healthy {
+    background: linear-gradient(90deg, #4CAF50, #8BC34A);
+}
+
+.health-fill.medium {
+    background: linear-gradient(90deg, #8BC34A, #CDDC39);
+}
+
+.health-fill.low {
+    background: linear-gradient(90deg, #FF9800, #FFC107);
+}
+
+.health-fill.critical {
+    background: linear-gradient(90deg, #F44336, #FF5722);
+    animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.7; }
+}
+
+.health-text {
+    text-align: center;
+    font-size: 12px;
+    margin-top: 4px;
+    color: white;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+}
+```
+
+### Type Display Component
+
+```typescript
+// components/type-badges.vue.ts
+export default defineComponent({
+    template: `
+        <div class="type-container">
+            <div v-for="(type, index) in types"
+                 :key="type"
+                 class="type-badge"
+                 :class="'type-' + type.toLowerCase()"
+                 :style="{ 
+                     backgroundColor: getTypeColor(type),
+                     animationDelay: (index * 0.1) + 's'
+                 }">
+                {{ localized ? localizedTypes[index] : type }}
+            </div>
+        </div>
+    `,
+    
+    props: {
+        types: {
+            type: Array as PropType<string[]>,
+            required: true
+        },
+        localizedTypes: {
+            type: Array as PropType<string[]>,
+            default: () => []
+        },
+        localized: {
+            type: Boolean,
+            default: false
+        },
+        animated: {
+            type: Boolean,
+            default: false
+        }
+    },
+    
+    methods: {
+        getTypeColor(type: string): string {
+            return V2.getTypeColor(type)
+        }
+    }
+})
+```
+
+```css
+.type-container {
+    display: flex;
+    gap: 6px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.type-badge {
+    padding: 6px 12px;
+    border-radius: 16px;
+    font-size: 11px;
+    font-weight: bold;
+    text-transform: uppercase;
+    color: white;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    opacity: 0;
+    animation: fadeInUp 0.5s ease forwards;
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Individual type styling */
+.type-fire { background: linear-gradient(135deg, #f08030, #ff6600); }
+.type-water { background: linear-gradient(135deg, #6890f0, #4169e1); }
+.type-grass { background: linear-gradient(135deg, #78c850, #228b22); }
+.type-electric { background: linear-gradient(135deg, #f8d030, #ffa500); }
+/* ... add all 18 types */
+```
+
+## Event Handling Examples
+
+### Death Counter with Animations
+
+```typescript
+createApp({
+    data() {
+        return {
+            party: [],
+            graveyard: [],
+            totalDeaths: 0,
+            recentDeath: null,
+            showDeathAnimation: false
+        }
+    },
+    
+    mounted() {
+        V2.initialize()
+        
+        V2.onPartyUpdate((party) => {
+            this.party = party
+        })
+        
+        V2.onDeath((pokemon, username) => {
+            this.totalDeaths++
+            this.recentDeath = pokemon
+            this.showDeathAnimation = true
+            
+            // Add to graveyard
+            this.graveyard.push({
+                ...pokemon,
+                deathTime: new Date(),
+                deathOrder: this.totalDeaths
+            })
+            
+            // Hide animation after 3 seconds
+            setTimeout(() => {
+                this.showDeathAnimation = false
+            }, 3000)
+            
+            // Play sound effect (optional)
+            this.playDeathSound()
+        })
+        
+        V2.onRevive((graveId) => {
+            const index = this.graveyard.findIndex(p => p.graveyardMeta?.id === graveId)
+            if (index !== -1) {
+                this.graveyard.splice(index, 1)
+                this.totalDeaths = Math.max(0, this.totalDeaths - 1)
+            }
+        })
+    },
+    
+    methods: {
+        playDeathSound() {
+            const audio = new Audio('assets/sounds/pokemon-faint.mp3')
+            audio.volume = 0.5
+            audio.play().catch(() => {
+                // Audio playback failed (user interaction required)
+            })
+        }
+    }
+}).mount('#death-tracker')
+```
+
+```html
+<!-- Death counter template -->
+<div id="death-tracker" class="death-counter">
+    <div class="death-stats">
+        <h2>💀 Deaths: {{ totalDeaths }}</h2>
+    </div>
+    
+    <!-- Death animation overlay -->
+    <div v-if="showDeathAnimation && recentDeath" class="death-overlay">
+        <div class="death-animation">
+            <img :src="getSprite(recentDeath)" class="fainted-sprite" />
+            <h3>{{ recentDeath.nickname || recentDeath.translations.english.speciesName }} fainted!</h3>
+        </div>
+    </div>
+    
+    <!-- Recent deaths -->
+    <div class="recent-deaths">
+        <h3>Recent Deaths</h3>
+        <div v-for="pokemon in graveyard.slice(-5)" 
+             :key="pokemon.deathOrder" 
+             class="death-entry">
+            <img :src="getSprite(pokemon)" class="grave-sprite" />
+            <span class="death-info">
+                {{ pokemon.translations.english.speciesName }}
+                <small>Level {{ pokemon.level }}</small>
+            </span>
+        </div>
+    </div>
+</div>
+```
+
+### Badge Progress Tracker
+
+```typescript
+createApp({
+    data() {
+        return {
+            badges: [],
+            newlyEarned: [],
+            badgeProgress: 0
+        }
+    },
+    
+    mounted() {
+        V2.onBadgeUpdate((badges, username) => {
+            // Detect newly earned badges
+            const previousEarned = this.badges.filter(b => b.obtained).map(b => b.id)
+            const currentEarned = badges.filter(b => b.obtained).map(b => b.id)
+            const newBadgeIds = currentEarned.filter(id => !previousEarned.includes(id))
+            
+            // Show celebration for new badges
+            if (newBadgeIds.length > 0) {
+                this.newlyEarned = badges.filter(b => newBadgeIds.includes(b.id))
+                this.celebrateNewBadges()
+            }
+            
+            this.badges = badges
+            this.badgeProgress = Math.round((currentEarned.length / badges.length) * 100)
+        })
+    },
+    
+    methods: {
+        celebrateNewBadges() {
+            // Show celebration animation
+            this.$nextTick(() => {
+                this.newlyEarned.forEach((badge, index) => {
+                    setTimeout(() => {
+                        this.animateBadgeEarned(badge)
+                    }, index * 500)
+                })
+                
+                // Clear after animations complete
+                setTimeout(() => {
+                    this.newlyEarned = []
+                }, this.newlyEarned.length * 500 + 2000)
+            })
+        },
+        
+        animateBadgeEarned(badge) {
+            // Create celebration element
+            const celebration = document.createElement('div')
+            celebration.className = 'badge-celebration'
+            celebration.innerHTML = `
+                <img src="${badge.sprite}" alt="${badge.englishName}" />
+                <p>You earned the ${badge.localeName}!</p>
+            `
+            document.body.appendChild(celebration)
+            
+            // Remove after animation
+            setTimeout(() => {
+                celebration.remove()
+            }, 3000)
+        }
+    }
+}).mount('#badge-tracker')
+```
+
+## Utility Function Examples
+
+### Pokemon Filtering and Sorting
+
+```typescript
+// Useful computed properties for themes
+computed: {
+    // Alive Pokemon only
+    alivePokemon(): Pokemon[] {
+        return this.party.filter(p => p !== null && p.hp.current > 0)
+    },
+    
+    // Sort by level (highest first)
+    pokemonByLevel(): Pokemon[] {
+        return [...this.alivePokemon].sort((a, b) => b.level - a.level)
+    },
+    
+    // Group by type
+    pokemonByType(): Map<string, Pokemon[]> {
+        const grouped = new Map()
+        
+        this.alivePokemon.forEach(pokemon => {
+            pokemon.translations.english.types.forEach(type => {
+                if (!grouped.has(type)) {
+                    grouped.set(type, [])
+                }
+                grouped.get(type).push(pokemon)
+            })
+        })
+        
+        return grouped
+    },
+    
+    // Find strongest Pokemon (by base stat total)
+    strongestPokemon(): Pokemon | null {
+        if (this.alivePokemon.length === 0) return null
+        
+        return this.alivePokemon.reduce((strongest, current) => {
+            return current.baseStats.bst > strongest.baseStats.bst ? current : strongest
+        })
+    },
+    
+    // Calculate team effectiveness against a type
+    teamEffectivenessVs(targetType: string): number {
+        const effectiveness = this.alivePokemon.map(pokemon => {
+            return this.calculateTypeEffectiveness(pokemon.translations.english.types, [targetType])
+        })
+        
+        return effectiveness.reduce((sum, eff) => sum + eff, 0) / effectiveness.length
+    }
+},
+
+methods: {
+    // Calculate type effectiveness (simplified)
+    calculateTypeEffectiveness(attackerTypes: string[], defenderTypes: string[]): number {
+        const effectiveness = {
+            'Fire': { 'Grass': 2, 'Ice': 2, 'Bug': 2, 'Steel': 2, 'Water': 0.5, 'Fire': 0.5, 'Rock': 0.5, 'Dragon': 0.5 },
+            'Water': { 'Fire': 2, 'Ground': 2, 'Rock': 2, 'Water': 0.5, 'Grass': 0.5, 'Dragon': 0.5 },
+            // ... complete type chart
+        }
+        
+        let multiplier = 1
+        
+        attackerTypes.forEach(attackType => {
+            defenderTypes.forEach(defenderType => {
+                const chart = effectiveness[attackType]
+                if (chart && chart[defenderType]) {
+                    multiplier *= chart[defenderType]
+                }
+            })
+        })
+        
+        return multiplier
+    },
+    
+    // Format Pokemon nickname with fallback
+    formatPokemonName(pokemon: Pokemon): string {
+        const nickname = pokemon.nickname
+        const species = pokemon.translations.english.speciesName
+        
+        if (nickname && nickname !== species) {
+            return `${nickname} (${species})`
+        }
+        return species
+    },
+    
+    // Get Pokemon color theme
+    getPokemonThemeColor(pokemon: Pokemon): string {
+        // Use provided color or generate from species name
+        return pokemon.color || string2ColHex(pokemon.translations.english.speciesName)
+    }
+}
+```
+
+### Animation Utilities
+
+```typescript
+// Animation helper methods
+methods: {
+    // Smooth counter animation
+    animateNumber(target: HTMLElement, start: number, end: number, duration: number = 1000) {
+        const startTime = performance.now()
+        const difference = end - start
+        
+        const updateNumber = (currentTime: number) => {
+            const elapsed = currentTime - startTime
+            const progress = Math.min(elapsed / duration, 1)
+            
+            // Easing function (ease out)
+            const easeOut = 1 - Math.pow(1 - progress, 3)
+            const current = start + (difference * easeOut)
+            
+            target.textContent = Math.round(current).toString()
+            
+            if (progress < 1) {
+                requestAnimationFrame(updateNumber)
+            }
+        }
+        
+        requestAnimationFrame(updateNumber)
+    },
+    
+    // Shake animation for damage
+    shakeElement(element: HTMLElement, intensity: number = 10, duration: number = 500) {
+        const originalPosition = element.style.transform
+        let startTime = 0
+        
+        const animate = (currentTime: number) => {
+            if (startTime === 0) startTime = currentTime
+            
+            const elapsed = currentTime - startTime
+            const progress = elapsed / duration
+            
+            if (progress < 1) {
+                const x = (Math.random() - 0.5) * intensity * (1 - progress)
+                const y = (Math.random() - 0.5) * intensity * (1 - progress)
+                
+                element.style.transform = `translate(${x}px, ${y}px) ${originalPosition}`
+                requestAnimationFrame(animate)
+            } else {
+                element.style.transform = originalPosition
+            }
+        }
+        
+        requestAnimationFrame(animate)
+    },
+    
+    // Bounce animation for level ups
+    bounceElement(element: HTMLElement) {
+        element.style.animation = 'bounce 0.6s ease'
+        
+        element.addEventListener('animationend', () => {
+            element.style.animation = ''
+        }, { once: true })
+    }
+}
+```
+
+```css
+/* Animation keyframes */
+@keyframes bounce {
+    0%, 20%, 53%, 80%, 100% {
+        transform: translate3d(0, 0, 0);
+    }
+    40%, 43% {
+        transform: translate3d(0, -30px, 0);
+    }
+    70% {
+        transform: translate3d(0, -15px, 0);
+    }
+    90% {
+        transform: translate3d(0, -4px, 0);
+    }
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes slideInLeft {
+    from {
+        opacity: 0;
+        transform: translateX(-100px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+    100% { transform: scale(1); }
+}
+```
+
+## Responsive Design Examples
+
+### Mobile-Friendly Theme
+
+```css
+/* Base desktop styles */
+.pokemon-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    padding: 20px;
+}
+
+.pokemon-card {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 15px;
+    padding: 20px;
+    text-align: center;
+}
+
+/* Tablet styles */
+@media (max-width: 1024px) {
+    .pokemon-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 15px;
+        padding: 15px;
+    }
+    
+    .pokemon-card {
+        padding: 15px;
+    }
+}
+
+/* Mobile styles */
+@media (max-width: 768px) {
+    .pokemon-grid {
+        grid-template-columns: 1fr;
+        gap: 10px;
+        padding: 10px;
+    }
+    
+    .pokemon-card {
+        padding: 12px;
+        border-radius: 10px;
+    }
+    
+    .sprite {
+        max-width: 100px;
+        max-height: 100px;
+    }
+    
+    h3 {
+        font-size: 16px;
+    }
+    
+    .level {
+        font-size: 14px;
+    }
+}
+
+/* Small mobile styles */
+@media (max-width: 480px) {
+    .pokemon-card {
+        padding: 8px;
+    }
+    
+    .sprite {
+        max-width: 80px;
+        max-height: 80px;
+    }
+    
+    h3 {
+        font-size: 14px;
+        margin: 8px 0 4px 0;
+    }
+    
+    .types {
+        gap: 3px;
+    }
+    
+    .type-badge {
+        padding: 3px 6px;
+        font-size: 10px;
+    }
+}
+
+/* Ultra-wide display support */
+@media (min-width: 1920px) {
+    .pokemon-grid {
+        grid-template-columns: repeat(6, 1fr);
+        max-width: 1800px;
+        margin: 0 auto;
+    }
+}
+```
+
+### Dynamic Layout Based on Party Size
+
+```typescript
+computed: {
+    gridColumns(): number {
+        const aliveCount = this.party.filter(p => p !== null).length
+        
+        if (aliveCount <= 2) return 2
+        if (aliveCount <= 4) return 2
+        return 3
+    },
+    
+    gridClass(): string {
+        return `grid-cols-${this.gridColumns}`
+    }
+}
+```
+
+```css
+.grid-cols-1 { grid-template-columns: 1fr; }
+.grid-cols-2 { grid-template-columns: repeat(2, 1fr); }
+.grid-cols-3 { grid-template-columns: repeat(3, 1fr); }
+.grid-cols-4 { grid-template-columns: repeat(4, 1fr); }
+.grid-cols-6 { grid-template-columns: repeat(6, 1fr); }
+```
+
+## Performance Optimization Examples
+
+### Efficient List Rendering
+
+```typescript
+// Use Object.freeze() for static data to prevent Vue reactivity overhead
+mounted() {
+    this.typeEffectiveness = Object.freeze({
+        'Fire': Object.freeze(['Grass', 'Ice', 'Bug', 'Steel']),
+        'Water': Object.freeze(['Fire', 'Ground', 'Rock']),
+        // ... etc
+    })
+}
+
+// Memoize expensive calculations
+computed: {
+    memoizedPartyStats: {
+        get() {
+            const key = this.party.map(p => p?.pid || 0).join(',')
+            
+            if (this.partyStatsCache.key === key) {
+                return this.partyStatsCache.value
+            }
+            
+            const stats = this.calculatePartyStats()
+            this.partyStatsCache = { key, value: stats }
+            return stats
+        }
+    }
+},
+
+// Use v-memo for expensive list items
+template: `
+    <div v-for="pokemon in party" 
+         :key="pokemon?.pid || 0"
+         v-memo="[pokemon?.pid, pokemon?.hp.current, pokemon?.level]"
+         class="pokemon-card">
+        <!-- Expensive rendering here -->
+    </div>
+`
+```
+
+### Image Optimization
+
+```typescript
+methods: {
+    // Preload sprites
+    preloadSprites() {
+        this.party.forEach(pokemon => {
+            if (pokemon) {
+                const img = new Image()
+                img.src = V2.getSprite(pokemon)
+                
+                // Also preload fallback
+                if (pokemon.fallbackSprite) {
+                    const fallback = new Image()
+                    fallback.src = pokemon.fallbackSprite
+                }
+            }
+        })
+    },
+    
+    // Lazy load images
+    setupLazyLoading() {
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    const img = entry.target as HTMLImageElement
+                    const src = img.dataset.src
+                    if (src) {
+                        img.src = src
+                        img.removeAttribute('data-src')
+                        observer.unobserve(img)
+                    }
+                }
+            })
+        })
+        
+        this.$el.querySelectorAll('img[data-src]').forEach(img => {
+            observer.observe(img)
+        })
+    }
+}
+```
+
+These examples provide a solid foundation for building custom PokeLink themes with various features and optimizations. Mix and match components based on your theme's needs!

--- a/docs/protobuf-schema.md
+++ b/docs/protobuf-schema.md
@@ -1,0 +1,382 @@
+# Protocol Buffer Schema Documentation
+
+This document describes the Protocol Buffer schemas used by PokeLink Web for data communication between the server and client.
+
+## Overview
+
+PokeLink Web supports two versions of Protocol Buffer schemas:
+- **V1 (Legacy):** Used with Socket.IO connections
+- **V2 (Modern):** Used with WebSocket connections, includes enhanced features
+
+### Generating Protocol Buffer Types
+
+Protocol Buffer definitions are automatically compiled to TypeScript during the build process:
+
+```bash
+# Generate protobuf types (recommended - uses Makefile)
+make buf-generate
+
+# Or use yarn directly
+yarn buf generate
+```
+
+Generated files:
+- `v2/assets/js/v2_pb.js` - Compiled protobuf code
+- TypeScript definitions for all message types
+- Serialization/deserialization functions
+
+> 📝 **Note**: Protocol Buffer generation is included in `make setup` and `make build`. Manual generation is only needed when modifying `.proto` files. See [Build System](build-system.md) for details.
+
+## V2 Protocol Buffer Schema
+
+The V2 schema is located at `v2/assets/proto/v2.proto` and provides comprehensive data structures for modern theme development.
+
+### Core Message Types
+
+#### Base Message
+All V2 messages extend from the Base message structure:
+
+```protobuf
+message Base {
+  string channel = 1;
+  optional string username = 2;
+}
+```
+
+**Fields:**
+- `channel`: Event channel identifier (e.g., "client:party:updated")
+- `username`: Username of the player (optional for some message types)
+
+### Party Data
+
+#### Party Message
+Main message for party updates:
+
+```protobuf
+message Party {
+  string channel = 1;
+  string username = 2;
+  repeated PartyObject party = 3;
+}
+```
+
+#### PartyObject
+Individual party slot container:
+
+```protobuf
+message PartyObject {
+  optional Pokemon pokemon = 1;
+  uint32 changeId = 2;
+}
+```
+
+**Fields:**
+- `pokemon`: Pokemon data (null for empty slots)
+- `changeId`: Incremental ID for tracking changes
+
+### Pokemon Data Structure
+
+#### Pokemon Message
+Comprehensive Pokemon data structure:
+
+```protobuf
+message Pokemon {
+  uint32 pid = 1;                    // Unique Pokemon ID
+  uint32 species = 2;                // National Dex number
+  uint32 level = 3;                  // Current level
+  uint32 exp = 4;                    // Current experience
+  uint32 expToNextLevel = 5;         // EXP needed for next level
+  double expPercentage = 6;          // Progress to next level (0.0-1.0)
+  HP hp = 7;                         // Health points
+  repeated Move moves = 8;           // Up to 4 moves
+  EVIV ivs = 9;                     // Individual Values
+  EVIV evs = 10;                    // Effort Values
+  BaseStats baseStats = 11;          // Base stat values
+  StatusEffect status = 12;          // Current status condition
+  PokemonTranslations translations = 13; // Localized names
+  bool hasFemaleSprite = 14;         // Gender sprite availability
+
+  // Optional fields
+  optional string color = 15;                // Theme color hex
+  optional string fallbackSprite = 16;      // Backup sprite URL
+  optional string fallbackPartySprite = 17; // Backup party sprite URL
+  optional string nickname = 18;            // Custom nickname
+  optional uint32 heldItem = 19;           // Held item ID
+  optional Gender gender = 20;              // Gender enum
+  optional uint32 form = 21;               // Alternate form ID
+  optional bool isEgg = 22;                // Egg status
+  optional uint32 hiddenPower = 23;        // Hidden Power type
+  optional uint32 nature = 24;             // Nature ID
+  optional bool isShiny = 25;              // Shiny status
+  optional uint32 pokeball = 26;           // Pokeball type ID
+  optional uint32 friendship = 27;          // Friendship value
+  optional uint32 ability = 28;            // Ability ID
+  optional Pokerus pokerus = 29;           // Pokerus status
+  optional uint32 locationMet = 30;        // Location caught
+  optional uint32 levelMet = 31;           // Level when caught
+  optional GraveMeta graveyardMeta = 32;   // Death metadata
+}
+```
+
+#### Supporting Structures
+
+##### HP (Health Points)
+```protobuf
+message HP {
+  uint32 max = 1;     // Maximum HP
+  uint32 current = 2; // Current HP
+}
+```
+
+##### Move
+```protobuf
+message Move {
+  uint32 id = 1;              // Move ID
+  uint32 pp = 2;              // Current PP
+  uint32 maxPP = 3;           // Maximum PP
+  MoveTranslation english = 4; // English names/types
+  MoveTranslation locale = 5;  // Localized names/types
+}
+```
+
+##### EVIV (Stats Container)
+Used for both EVs (Effort Values) and IVs (Individual Values):
+
+```protobuf
+message EVIV {
+  uint32 atk = 1;    // Attack
+  uint32 def = 2;    // Defense
+  uint32 spatk = 3;  // Special Attack
+  uint32 spdef = 4;  // Special Defense
+  uint32 spd = 5;    // Speed
+  uint32 hp = 6;     // HP
+}
+```
+
+##### BaseStats
+```protobuf
+message BaseStats {
+  uint32 atk = 1;    // Base Attack
+  uint32 def = 2;    // Base Defense
+  uint32 spatk = 3;  // Base Special Attack
+  uint32 spdef = 4;  // Base Special Defense
+  uint32 spd = 5;    // Base Speed
+  uint32 hp = 6;     // Base HP
+  uint32 bst = 7;    // Base Stat Total
+}
+```
+
+### Translations and Localization
+
+#### PokemonTranslations
+```protobuf
+message PokemonTranslations {
+  TranslationsObject english = 1; // English names
+  TranslationsObject locale = 2;  // User's locale names
+}
+```
+
+#### TranslationsObject
+```protobuf
+message TranslationsObject {
+  string speciesName = 1;           // Pokemon species name
+  string status = 2;                // Status condition name
+  repeated string types = 3;        // Type names array
+  optional string formName = 4;     // Alternate form name
+  optional string heldItemName = 5; // Held item name
+  optional string gender = 6;       // Gender string
+  optional string hiddenPowerName = 7; // Hidden Power type name
+  optional string pokeballName = 8; // Pokeball name
+  optional string abilityName = 9;  // Ability name
+  optional string pokerusStatus = 10; // Pokerus status string
+  optional string locationMetName = 11; // Location name
+  optional string natureName = 12;  // Nature name
+}
+```
+
+### Enumerations
+
+#### Gender
+```protobuf
+enum Gender {
+  male = 0;
+  female = 1;
+  genderless = 2;
+}
+```
+
+#### StatusEffect
+```protobuf
+enum StatusEffect {
+  healthy = 0;
+  poisoned = 1;
+  asleep = 2;
+  paralyzed = 3;
+  frozen = 4;
+  burned = 5;
+}
+```
+
+#### Pokerus
+```protobuf
+enum Pokerus {
+  clean = 0;
+  infected = 1;
+  cured = 2;
+}
+```
+
+### Badge System
+
+#### Badges Message
+```protobuf
+message Badges {
+  string channel = 1;
+  string username = 2;
+  repeated Badge badges = 3;
+}
+```
+
+#### Badge
+```protobuf
+message Badge {
+  string id = 1;                    // Unique badge identifier
+  string localeName = 2;            // Localized badge name
+  string englishName = 3;           // English badge name
+  bool obtained = 4;                // Whether badge is obtained
+  string sprite = 5;                // Badge sprite URL
+  optional string englishCategory = 6;  // Badge category (English)
+  optional string localeCategory = 7;   // Badge category (localized)
+  optional string levelText = 8;    // Level cap text
+  optional uint32 levelCap = 9;     // Numerical level cap
+}
+```
+
+### Graveyard System
+
+#### GraveyardUpdate Message
+```protobuf
+message GraveyardUpdate {
+  string channel = 1;
+  string username = 2;
+  repeated Pokemon graves = 3;
+}
+```
+
+#### GraveMeta
+Death metadata for fallen Pokemon:
+
+```protobuf
+message GraveMeta {
+  google.protobuf.Timestamp timeOfDeath = 1; // When Pokemon fainted
+  string id = 2;                             // Unique grave identifier
+}
+```
+
+### Death and Revival Events
+
+#### PokemonDeath Message
+```protobuf
+message PokemonDeath {
+  string channel = 1;
+  string username = 2;
+  Pokemon pokemon = 3;
+}
+```
+
+#### PokemonRevive Message
+```protobuf
+message PokemonRevive {
+  string channel = 1;
+  string username = 2;
+  string graveId = 3;  // ID of the grave to revive from
+}
+```
+
+### Settings System
+
+#### Settings Message
+```protobuf
+message Settings {
+  string channel = 1;
+  string username = 2;
+  SettingsData data = 3;
+}
+```
+
+#### SettingsData
+```protobuf
+message SettingsData {
+  optional string spriteTemplate = 1; // Custom sprite template URL
+}
+```
+
+## V1 Protocol Buffer Schema (Legacy)
+
+The V1 schema is simpler and used for backward compatibility with older themes.
+
+### Key Differences from V2
+
+1. **Less structured data:** No comprehensive translation system
+2. **Simpler move system:** Only name and PP, no type information
+3. **Basic status system:** Numeric status values instead of enums
+4. **Limited metadata:** No graveyard timestamps or comprehensive stats
+
+### Legacy Pokemon Structure
+
+```protobuf
+message Pokemon {
+  optional bool isEgg = 1;
+  uint32 exp = 2;
+  HP hp = 3;
+  optional string nature = 4;
+  Move move1 = 5;
+  Move move2 = 6;
+  Move move3 = 7;
+  Move move4 = 8;
+  // ... additional fields
+}
+```
+
+## Channel Types
+
+### V2 Event Channels
+
+| Channel | Message Type | Description |
+|---------|--------------|-------------|
+| `client:party:updated` | Party | Party composition changed |
+| `client:badges:updated` | Badges | Badge status updated |
+| `client:party:death` | PokemonDeath | Pokemon fainted |
+| `client:party:revive` | PokemonRevive | Pokemon revived |
+| `client:settings:updated` | Settings | User settings changed |
+| `client:graveyard:updated` | GraveyardUpdate | Graveyard contents changed |
+
+### Usage in Themes
+
+```typescript
+// TypeScript example for handling protobuf messages
+import {fromBinary} from '@bufbuild/protobuf'
+import {PartySchema, PokemonDeathSchema} from './v2_pb.js'
+
+client.on('client:party:updated', (buffer: Uint8Array) => {
+  const partyMessage = fromBinary(PartySchema, buffer)
+  console.log(`Received party update for ${partyMessage.username}`)
+  
+  partyMessage.party.forEach((slot, index) => {
+    if (slot.pokemon) {
+      console.log(`Slot ${index + 1}: ${slot.pokemon.translations.english.speciesName}`)
+    }
+  })
+})
+```
+
+## Data Validation
+
+All protobuf messages are strongly typed and validated:
+
+- **Required fields** must be present
+- **Optional fields** can be null/undefined
+- **Enums** are validated against defined values
+- **Repeated fields** are arrays that can be empty
+
+This ensures type safety in TypeScript themes and prevents runtime errors from malformed data.

--- a/docs/theme-data-structures.md
+++ b/docs/theme-data-structures.md
@@ -1,0 +1,416 @@
+# Theme Data Structures
+
+This document describes the data structures available to theme developers when creating PokeLink Web themes.
+
+## Available Data Types
+
+All data types are strongly typed through TypeScript and Protocol Buffers, ensuring type safety and preventing runtime errors.
+
+### Pokemon Data Structure
+
+The `Pokemon` interface is the primary data structure theme developers will work with:
+
+```typescript
+interface Pokemon {
+  // Core identification
+  pid: number                    // Unique Pokemon instance ID
+  species: number               // National Pokedex number
+  level: number                 // Current level (1-100)
+  
+  // Experience and progression  
+  exp: number                   // Current experience points
+  expToNextLevel: number        // Experience needed for next level
+  expPercentage: number         // Progress to next level (0.0-1.0)
+  
+  // Health and status
+  hp: HP                        // Health point structure
+  status: StatusEffect          // Current status condition
+  
+  // Combat data
+  moves: Move[]                 // Array of up to 4 moves
+  ivs: EVIV                     // Individual Values
+  evs: EVIV                     // Effort Values  
+  baseStats: BaseStats          // Base stat values
+  
+  // Localization
+  translations: PokemonTranslations  // Names in multiple languages
+  
+  // Visual and metadata
+  color?: string                // Theme color (hex)
+  fallbackSprite?: string       // Backup sprite URL
+  fallbackPartySprite?: string  // Backup party sprite URL
+  hasFemaleSprite: boolean      // Has gender-specific sprite
+  
+  // Optional attributes
+  nickname?: string             // Custom nickname
+  heldItem?: number            // Held item ID
+  gender?: Gender              // Gender enum value
+  form?: number                // Alternate form ID
+  isEgg?: boolean              // Egg status
+  hiddenPower?: number         // Hidden Power type ID
+  nature?: number              // Nature ID
+  isShiny?: boolean            // Shiny status
+  pokeball?: number            // Capture ball type ID
+  friendship?: number          // Friendship value (0-255)
+  ability?: number             // Ability ID
+  pokerus?: Pokerus            // Pokerus status
+  locationMet?: number         // Location where caught
+  levelMet?: number            // Level when caught
+  graveyardMeta?: GraveMeta    // Death information (if applicable)
+}
+```
+
+### Supporting Data Structures
+
+#### HP (Health Points)
+```typescript
+interface HP {
+  max: number      // Maximum HP value
+  current: number  // Current HP value
+}
+
+// Usage example in themes
+const healthPercent = (pokemon.hp.current / pokemon.hp.max) * 100
+const isLowHealth = healthPercent <= 25
+const isCriticalHealth = healthPercent <= 10
+```
+
+#### Move Structure
+```typescript
+interface Move {
+  id: number                  // Move ID from game data
+  pp: number                  // Current Power Points
+  maxPP: number              // Maximum Power Points
+  english: MoveTranslation   // English names and types
+  locale: MoveTranslation    // Localized names and types
+}
+
+interface MoveTranslation {
+  name: string               // Move name
+  type: string              // Move type
+  secondType?: string       // Secondary type (for moves like Flying Press)
+}
+
+// Usage example
+pokemon.moves.forEach(move => {
+  console.log(`${move.english.name} (${move.english.type}): ${move.pp}/${move.maxPP} PP`)
+})
+```
+
+#### EVIV (Stats Container)
+Used for both Individual Values (IVs) and Effort Values (EVs):
+
+```typescript
+interface EVIV {
+  atk: number     // Attack
+  def: number     // Defense  
+  spatk: number   // Special Attack
+  spdef: number   // Special Defense
+  spd: number     // Speed
+  hp: number      // HP
+}
+
+// Usage examples
+const totalIVs = pokemon.ivs.atk + pokemon.ivs.def + pokemon.ivs.spatk + 
+                 pokemon.ivs.spdef + pokemon.ivs.spd + pokemon.ivs.hp
+
+const isCompetitiveIVs = totalIVs >= 186 // Perfect IVs = 186 (31*6)
+```
+
+#### BaseStats Structure
+```typescript
+interface BaseStats {
+  atk: number     // Base Attack stat
+  def: number     // Base Defense stat
+  spatk: number   // Base Special Attack stat
+  spdef: number   // Base Special Defense stat
+  spd: number     // Base Speed stat
+  hp: number      // Base HP stat
+  bst: number     // Base Stat Total (sum of all base stats)
+}
+
+// Usage for Pokemon strength categorization
+const isLegendary = pokemon.baseStats.bst >= 600
+const isPseudoLegendary = pokemon.baseStats.bst >= 580 && pokemon.baseStats.bst < 600
+```
+
+### Translation System
+
+#### PokemonTranslations
+All text data is provided in both English and the user's locale:
+
+```typescript
+interface PokemonTranslations {
+  english: TranslationsObject   // English translations
+  locale: TranslationsObject    // User's language translations
+}
+
+interface TranslationsObject {
+  speciesName: string           // Pokemon name (e.g., "Charizard")
+  status: string               // Status condition name
+  types: string[]              // Array of type names
+  formName?: string            // Alternate form name (e.g., "Mega X")
+  heldItemName?: string        // Held item name
+  gender?: string              // Gender string
+  hiddenPowerName?: string     // Hidden Power type name
+  pokeballName?: string        // Pokeball name
+  abilityName?: string         // Ability name
+  pokerusStatus?: string       // Pokerus status description
+  locationMetName?: string     // Location name
+  natureName?: string          // Nature name
+}
+```
+
+#### Usage in Templates
+```vue
+<template>
+  <div class="pokemon-card">
+    <!-- Use nickname if available, otherwise species name -->
+    <h3>{{ pokemon.nickname || pokemon.translations.locale.speciesName }}</h3>
+    
+    <!-- Show types with proper localization -->
+    <div class="types">
+      <span v-for="type in pokemon.translations.english.types" 
+            :key="type" 
+            :class="'type-' + type.toLowerCase()">
+        {{ pokemon.translations.locale.types[pokemon.translations.english.types.indexOf(type)] }}
+      </span>
+    </div>
+    
+    <!-- Status with localized text -->
+    <div v-if="pokemon.status !== 'healthy'" class="status">
+      {{ pokemon.translations.locale.status }}
+    </div>
+  </div>
+</template>
+```
+
+### Enumerations
+
+#### Gender
+```typescript
+enum Gender {
+  male = 0,
+  female = 1, 
+  genderless = 2
+}
+
+// Usage in sprite selection
+const spriteGenderSuffix = pokemon.gender === Gender.female && pokemon.hasFemaleSprite ? '-f' : ''
+```
+
+#### StatusEffect  
+```typescript
+enum StatusEffect {
+  healthy = 0,
+  poisoned = 1,
+  asleep = 2, 
+  paralyzed = 3,
+  frozen = 4,
+  burned = 5
+}
+
+// Usage for status styling
+const statusClass = {
+  [StatusEffect.poisoned]: 'status-poison',
+  [StatusEffect.asleep]: 'status-sleep', 
+  [StatusEffect.paralyzed]: 'status-paralysis',
+  [StatusEffect.frozen]: 'status-freeze',
+  [StatusEffect.burned]: 'status-burn'
+}[pokemon.status] || ''
+```
+
+#### Pokerus
+```typescript
+enum Pokerus {
+  clean = 0,    // No Pokerus
+  infected = 1, // Currently infected (spreads to others)
+  cured = 2     // Previously infected (immune, keeps benefits)
+}
+```
+
+### Party Data Structure
+
+The party is received as an array of Pokemon objects, with null entries for empty slots:
+
+```typescript
+type Party = (Pokemon | null)[]
+
+// Typical usage in Vue themes
+export default {
+  data() {
+    return {
+      party: [] as (Pokemon | null)[]
+    }
+  },
+  computed: {
+    // Filter out empty slots
+    activePokemon(): Pokemon[] {
+      return this.party.filter(p => p !== null) as Pokemon[]
+    },
+    
+    // Get specific slot (1-indexed for user display)
+    getSlot() {
+      return (slotNumber: number): Pokemon | null => {
+        return this.party[slotNumber - 1] || null
+      }
+    },
+    
+    // Check if party is full
+    isPartyFull(): boolean {
+      return this.party.filter(p => p !== null).length === 6
+    }
+  }
+}
+```
+
+### Badge Data Structure
+
+```typescript
+interface Badge {
+  id: string                    // Unique badge identifier
+  localeName: string           // Badge name in user's language
+  englishName: string          // Badge name in English
+  obtained: boolean            // Whether badge is earned
+  sprite: string               // Badge image URL
+  englishCategory?: string     // Category (English)
+  localeCategory?: string      // Category (localized)  
+  levelText?: string           // Level cap description
+  levelCap?: number           // Numerical level cap
+}
+
+// Usage in badge display
+const earnedBadges = badges.filter(badge => badge.obtained)
+const nextBadge = badges.find(badge => !badge.obtained)
+```
+
+### Graveyard Data Structure
+
+Fallen Pokemon retain all their original data plus death metadata:
+
+```typescript
+interface GraveMeta {
+  timeOfDeath: Date    // When the Pokemon fainted
+  id: string           // Unique identifier for the grave
+}
+
+// Graveyard is an array of Pokemon with graveyardMeta populated
+type Graveyard = Pokemon[]
+
+// Usage example
+const recentDeaths = graveyard
+  .filter(pokemon => pokemon.graveyardMeta)
+  .sort((a, b) => b.graveyardMeta!.timeOfDeath.getTime() - a.graveyardMeta!.timeOfDeath.getTime())
+  .slice(0, 5) // Show 5 most recent deaths
+```
+
+### Sprite and Asset URLs
+
+PokeLink provides multiple sprite sources with fallback mechanisms:
+
+```typescript
+// Primary sprite URL (customizable via sprite templates)
+const primarySprite = V2.getSprite(pokemon)
+
+// Party sprite (smaller, optimized for party display)  
+const partySprite = V2.getPartySprite(pokemon)
+
+// Fallback sprites (always available)
+const fallbackSprite = pokemon.fallbackSprite
+const fallbackPartySprite = pokemon.fallbackPartySprite
+
+// Held item sprite
+const itemSprite = clientSettings.itemSpriteTemplate(pokemon)
+```
+
+### Utility Data Types
+
+#### Nullable Type
+Many values can be null or undefined:
+
+```typescript
+type Nullable<T> = T | null | undefined
+
+// Utility function provided by PokeLink
+function isDefined<T>(value: Nullable<T>): value is T {
+  return value !== null && value !== undefined
+}
+
+// Usage
+if (isDefined(pokemon.nickname)) {
+  // TypeScript now knows pokemon.nickname is definitely a string
+  displayName = pokemon.nickname.toUpperCase()
+}
+```
+
+### Color and Theming Data
+
+PokeLink provides color systems for consistent theming:
+
+```typescript
+// Type colors (official Pokemon type colors)
+const typeColors: { [key: string]: string } = {
+  'Fire': '#f08030',
+  'Water': '#6890f0', 
+  'Grass': '#78c850',
+  'Electric': '#f8d030',
+  // ... all 18 types
+}
+
+// Status condition colors
+const statusColors: { [key: string]: string } = {
+  'Poisoned': '#c060c0',
+  'Paralyzed': '#b8b818',
+  'Asleep': '#a0a088',
+  'Frozen': '#88b0e0',
+  'Burned': '#e07050',
+  'Fainted': '#e85038'
+}
+
+// Usage in themes
+const typeColor = V2.getTypeColor(pokemon.translations.english.types[0])
+const statusColor = V2.getStatusColor(pokemon.translations.english.status)
+
+// Pokemon-specific theme color (generated from species name)
+const pokemonColor = pokemon.color || string2ColHex(pokemon.translations.english.speciesName)
+```
+
+### Real-time Data Updates
+
+All data structures are reactive and updated in real-time:
+
+```typescript
+// Vue theme example
+export default {
+  mounted() {
+    // Listen for party updates
+    V2.onPartyUpdate((newParty: (Pokemon | null)[]) => {
+      this.party = newParty
+      // Vue automatically re-renders when party changes
+    })
+    
+    // Listen for badge updates  
+    V2.onBadgeUpdate((badges: Badge[]) => {
+      this.badges = badges
+    })
+    
+    // Listen for deaths (for graveyard themes)
+    V2.onDeath((pokemon: Pokemon) => {
+      this.graveyard.push(pokemon)
+      // Play death animation, update counters, etc.
+    })
+  }
+}
+```
+
+### Data Validation and Safety
+
+All data is validated through Protocol Buffers and TypeScript:
+
+- **Type Safety**: All fields are strongly typed
+- **Required Fields**: Core fields like `pid`, `species`, `level` are always present  
+- **Optional Fields**: Marked with `?` and can be safely checked with `isDefined()`
+- **Enum Validation**: Status, gender, and pokerus values are validated against defined enums
+- **Array Safety**: Move arrays, type arrays, etc. are guaranteed to be proper arrays
+
+This comprehensive type system prevents common theme development errors and ensures reliable data access patterns.

--- a/docs/theme-development-guide.md
+++ b/docs/theme-development-guide.md
@@ -1,0 +1,835 @@
+# Theme Development Guide
+
+This guide walks you through creating custom themes for PokeLink Web, from basic setup to advanced techniques.
+
+## Getting Started
+
+### Prerequisites
+
+Before developing themes, ensure you have:
+
+- **Node.js** (14+) and **Yarn** installed
+- **PokeLink server** running locally
+- **Code editor** with TypeScript support (VS Code recommended)
+- **Browser** for testing (Chrome/Firefox recommended)
+
+### Development Environment Setup
+
+1. **Clone and Setup PokeLink Web:**
+```bash
+git clone https://github.com/pokelinkapp/pokelink-web.git
+cd pokelink-web/v2
+
+# Initial setup (recommended - uses Makefile)
+make setup
+
+# Or use yarn directly
+yarn install
+```
+
+2. **Build the Core Libraries:**
+```bash
+# Using Makefile (recommended)
+make build-core
+
+# Or use yarn directly
+yarn build:core
+```
+
+3. **Start Development:**
+```bash
+# Development mode with watch (recommended - uses Makefile)
+make dev
+
+# Or watch for changes and rebuild automatically
+yarn build --watch
+```
+
+> 💡 **Tip**: The Makefile provides colored output, better error handling, and more intuitive commands. See the [Build System Documentation](build-system.md) for complete details.
+
+### Project Structure for Themes
+
+```
+v2/themes/
+├── _shared/                 # Shared components across themes
+│   └── components/
+├── your-theme-name/        # Your custom theme
+│   ├── assets/
+│   │   ├── css/
+│   │   │   └── styles.css  # Theme-specific styling
+│   │   └── js/
+│   │       ├── components/ # Vue components (optional)
+│   │       └── party.ts   # Main theme script
+│   └── index.html         # Theme entry point
+```
+
+## Creating Your First Theme
+
+### Step 1: Create Theme Directory
+
+```bash
+mkdir v2/themes/my-first-theme
+cd v2/themes/my-first-theme
+mkdir -p assets/{css,js}
+```
+
+### Step 2: Create HTML Entry Point
+
+Create `index.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My First PokeLink Theme</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+    <div id="party" v-show="loaded">
+        <div v-if="!connected" class="no-connection">
+            Disconnected
+        </div>
+
+        <div class="pokemon-container">
+            <div v-for="(pokemon, index) in pokemonToShow"
+                 :key="pokemon?.pid || index"
+                 class="pokemon-slot">
+
+                <div v-if="pokemon" class="pokemon-card">
+                    <!-- Pokemon sprite -->
+                    <img :src="getSprite(pokemon)"
+                         @error="useFallback($event.target, pokemon)"
+                         :alt="pokemon.translations.english.speciesName"
+                         class="sprite" />
+
+                    <!-- Pokemon name -->
+                    <h3>{{ pokemon.nickname || pokemon.translations.english.speciesName }}</h3>
+
+                    <!-- Level -->
+                    <div class="level">Lv. {{ pokemon.level }}</div>
+
+                    <!-- HP Bar -->
+                    <div class="hp-container" v-if="showHP">
+                        <div class="hp-bar">
+                            <div class="hp-fill"
+                                 :style="{ width: getHPPercent(pokemon) + '%' }"
+                                 :class="getHPClass(pokemon)">
+                            </div>
+                        </div>
+                        <div class="hp-text">
+                            {{ pokemon.hp.current }} / {{ pokemon.hp.max }}
+                        </div>
+                    </div>
+
+                    <!-- Types -->
+                    <div class="types">
+                        <span v-for="type in pokemon.translations.english.types"
+                              :key="type"
+                              class="type"
+                              :style="{ backgroundColor: getTypeColor(type) }">
+                            {{ type }}
+                        </span>
+                    </div>
+                </div>
+
+                <!-- Empty slot -->
+                <div v-else class="empty-slot">
+                    <div class="pokeball-empty"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Load PokeLink core libraries -->
+    <script src="../../assets/dist/client.js"></script>
+    <script src="../../assets/dist/global.js"></script>
+    <script src="../../assets/dist/pokelink.js"></script>
+    <script src="assets/js/party.js"></script>
+</body>
+</html>
+```
+
+### Step 3: Create Theme Logic
+
+Create `assets/js/party.ts`:
+
+```typescript
+import { createApp } from 'vue'
+import { V2, clientSettings, isDefined } from 'pokelink'
+import type { Nullable } from 'global'
+import type { Pokemon } from 'v2Proto'
+
+(() => {
+    createApp({
+        data() {
+            return {
+                connected: false,
+                loaded: false,
+                party: [] as (Pokemon | null)[],
+                showHP: true
+            }
+        },
+
+        mounted() {
+            // Initialize PokeLink connection
+            V2.initialize({
+                numberOfPlayers: 1,
+                listenForSpriteUpdates: true
+            })
+
+            // Get URL parameters
+            this.showHP = clientSettings.params.getBool('hp', true)
+
+            // Listen for party updates
+            V2.onPartyUpdate((party: (Pokemon | null)[]) => {
+                this.party = party
+                this.loaded = true
+                this.$forceUpdate()
+            })
+
+            // Listen for connection events
+            V2.onConnect(() => {
+                this.connected = true
+            })
+        },
+
+        computed: {
+            pokemonToShow(): (Pokemon | null)[] {
+                // Show single slot if specified
+                if (clientSettings.params.hasKey('slot')) {
+                    const slotIndex = clientSettings.params.getNumber('slot', 1) - 1
+                    return [this.party[slotIndex] || null]
+                }
+
+                // Show all party slots
+                return this.party
+            }
+        },
+
+        methods: {
+            getSprite(pokemon: Pokemon): string {
+                return V2.getSprite(pokemon)
+            },
+
+            useFallback(img: HTMLImageElement, pokemon: Pokemon): void {
+                V2.useFallback(img, pokemon)
+            },
+
+            getHPPercent(pokemon: Pokemon): number {
+                if (!pokemon.hp || pokemon.hp.max === 0) return 0
+                return (pokemon.hp.current / pokemon.hp.max) * 100
+            },
+
+            getHPClass(pokemon: Pokemon): string {
+                const percent = this.getHPPercent(pokemon)
+                if (percent <= 15) return 'critical'
+                if (percent <= 50) return 'low'
+                return 'healthy'
+            },
+
+            getTypeColor(type: string): string {
+                return V2.getTypeColor(type)
+            }
+        }
+    }).mount('#party')
+})()
+```
+
+### Step 4: Create Basic Styling
+
+Create `assets/css/styles.css`:
+
+```css
+/* Reset and base styles */
+html, body {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    font-family: 'Arial', sans-serif;
+    color: white;
+}
+
+/* Connection indicator */
+.no-connection {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(255, 0, 0, 0.8);
+    padding: 20px;
+    border-radius: 10px;
+    font-size: 24px;
+    z-index: 1000;
+}
+
+/* Pokemon container */
+.pokemon-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding: 20px;
+    justify-content: center;
+}
+
+/* Pokemon card */
+.pokemon-card {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 15px;
+    padding: 20px;
+    text-align: center;
+    backdrop-filter: blur(5px);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    min-width: 200px;
+    transition: transform 0.3s ease;
+}
+
+.pokemon-card:hover {
+    transform: translateY(-5px);
+}
+
+/* Pokemon sprite */
+.sprite {
+    max-width: 150px;
+    max-height: 150px;
+    image-rendering: pixelated; /* For pixel art sprites */
+}
+
+/* Pokemon name */
+.pokemon-card h3 {
+    margin: 15px 0 10px 0;
+    font-size: 18px;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
+}
+
+/* Level display */
+.level {
+    font-size: 16px;
+    font-weight: bold;
+    margin-bottom: 15px;
+    color: #ffd700;
+}
+
+/* HP Bar */
+.hp-container {
+    margin: 15px 0;
+}
+
+.hp-bar {
+    width: 100%;
+    height: 20px;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 10px;
+    overflow: hidden;
+    border: 2px solid #333;
+}
+
+.hp-fill {
+    height: 100%;
+    transition: width 1s ease, background-color 0.3s ease;
+    border-radius: 8px;
+}
+
+.hp-fill.healthy {
+    background: linear-gradient(90deg, #4CAF50, #8BC34A);
+}
+
+.hp-fill.low {
+    background: linear-gradient(90deg, #FF9800, #FFC107);
+}
+
+.hp-fill.critical {
+    background: linear-gradient(90deg, #F44336, #FF5722);
+}
+
+.hp-text {
+    font-size: 14px;
+    margin-top: 5px;
+}
+
+/* Type badges */
+.types {
+    display: flex;
+    gap: 5px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-top: 10px;
+}
+
+.type {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: bold;
+    text-transform: uppercase;
+    color: white;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+/* Empty slot */
+.empty-slot {
+    width: 200px;
+    height: 300px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed rgba(255, 255, 255, 0.3);
+    border-radius: 15px;
+    background: rgba(0, 0, 0, 0.1);
+}
+
+.pokeball-empty {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 30%, #ddd, #999);
+    position: relative;
+    opacity: 0.3;
+}
+
+.pokeball-empty::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: #333;
+    transform: translateY(-1px);
+}
+
+.pokeball-empty::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: #333;
+    transform: translate(-50%, -50%);
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    .pokemon-container {
+        flex-direction: column;
+        align-items: center;
+        padding: 10px;
+    }
+
+    .pokemon-card {
+        width: 100%;
+        max-width: 300px;
+    }
+}
+```
+
+### Step 5: Build and Test
+
+1. **Build the theme:**
+```bash
+# Using Makefile (recommended)
+make build-themes
+
+# Or use yarn directly
+yarn build:themes
+```
+
+2. **Test the theme:**
+```bash
+# Open in browser with your PokeLink username
+file:///path/to/pokelink-web/v2/themes/my-first-theme/index.html?user=YourUsername
+```
+
+> 📝 **Development Workflow**: Use `make dev` to automatically rebuild your theme as you make changes, then refresh your browser to see updates instantly.
+
+## Advanced Theme Development
+
+### Custom Vue Components
+
+Create reusable components for complex themes:
+
+Create `assets/js/components/pokemon-card.vue.ts`:
+
+```typescript
+import { defineComponent, PropType } from 'vue'
+import { V2 } from 'pokelink'
+import { Pokemon } from 'v2Proto'
+
+export default defineComponent({
+    template: `
+        <div class="advanced-pokemon-card" :class="cardClasses">
+            <div class="card-header">
+                <img :src="V2.getSprite(pokemon)"
+                     @error="handleSpriteError"
+                     class="pokemon-sprite" />
+                <div class="shiny-indicator" v-if="pokemon.isShiny">✨</div>
+            </div>
+
+            <div class="card-body">
+                <h3 class="pokemon-name">
+                    {{ pokemon.nickname || pokemon.translations.english.speciesName }}
+                </h3>
+
+                <div class="pokemon-level">Lv. {{ pokemon.level }}</div>
+
+                <div class="pokemon-types">
+                    <type-badge v-for="type in pokemon.translations.english.types"
+                               :key="type"
+                               :type="type" />
+                </div>
+
+                <health-bar :pokemon="pokemon" v-if="showHealth" />
+
+                <div class="pokemon-stats" v-if="showStats">
+                    <stat-display label="ATK" :value="pokemon.baseStats.atk" />
+                    <stat-display label="DEF" :value="pokemon.baseStats.def" />
+                    <stat-display label="SPA" :value="pokemon.baseStats.spatk" />
+                    <stat-display label="SPD" :value="pokemon.baseStats.spdef" />
+                    <stat-display label="SPE" :value="pokemon.baseStats.spd" />
+                </div>
+            </div>
+        </div>
+    `,
+
+    props: {
+        pokemon: {
+            type: Object as PropType<Pokemon>,
+            required: true
+        },
+        showHealth: {
+            type: Boolean,
+            default: true
+        },
+        showStats: {
+            type: Boolean,
+            default: false
+        }
+    },
+
+    computed: {
+        cardClasses(): string[] {
+            const classes = []
+
+            if (this.pokemon.isShiny) classes.push('shiny')
+            if (this.pokemon.status !== 0) classes.push('status-affected')
+            if (this.pokemon.isEgg) classes.push('egg')
+
+            return classes
+        }
+    },
+
+    methods: {
+        handleSpriteError(event: Event) {
+            V2.useFallback(event.target as HTMLImageElement, this.pokemon)
+        }
+    }
+})
+```
+
+### Multi-User Support
+
+Handle multiple players in a single theme:
+
+```typescript
+export default createApp({
+    data() {
+        return {
+            players: new Map<string, (Pokemon | null)[]>(),
+            connected: false
+        }
+    },
+
+    mounted() {
+        V2.initialize({
+            numberOfPlayers: -1  // Track all players
+        })
+
+        V2.onPartyUpdate((party, username) => {
+            this.players.set(username, party)
+            this.$forceUpdate()
+        })
+    },
+
+    computed: {
+        displayedPlayers(): Array<{username: string, party: (Pokemon | null)[]}> {
+            const targetUsers = clientSettings.params.getString('users', '').split(',')
+
+            return Array.from(this.players.entries())
+                .filter(([username]) => targetUsers.includes(username))
+                .map(([username, party]) => ({ username, party }))
+        }
+    }
+})
+```
+
+### Animation System
+
+Add smooth animations for state changes:
+
+```typescript
+// In your theme's Vue app
+methods: {
+    onPartyUpdate(newParty: (Pokemon | null)[]) {
+        // Detect changes
+        const changes = this.detectPartyChanges(this.party, newParty)
+
+        // Animate changes
+        changes.forEach(change => {
+            switch (change.type) {
+                case 'pokemon_added':
+                    this.animatePokemonAppear(change.slotIndex)
+                    break
+                case 'pokemon_removed':
+                    this.animatePokemonDisappear(change.slotIndex)
+                    break
+                case 'level_up':
+                    this.animateLevelUp(change.slotIndex, change.newLevel)
+                    break
+                case 'hp_changed':
+                    this.animateHPChange(change.slotIndex, change.oldHP, change.newHP)
+                    break
+            }
+        })
+
+        // Update party data
+        this.party = newParty
+    },
+
+    animatePokemonAppear(slotIndex: number) {
+        this.$nextTick(() => {
+            const element = this.$refs[`slot-${slotIndex}`] as HTMLElement
+            element.style.opacity = '0'
+            element.style.transform = 'scale(0.5)'
+
+            element.offsetHeight // Force reflow
+
+            element.style.transition = 'opacity 0.5s ease, transform 0.5s ease'
+            element.style.opacity = '1'
+            element.style.transform = 'scale(1)'
+        })
+    },
+
+    animateLevelUp(slotIndex: number, newLevel: number) {
+        // Create level up animation
+        const element = this.$refs[`level-${slotIndex}`] as HTMLElement
+        element.classList.add('level-up-animation')
+
+        setTimeout(() => {
+            element.classList.remove('level-up-animation')
+        }, 1000)
+    }
+}
+```
+
+### Custom Sprite Templates
+
+Create dynamic sprite loading with Handlebars:
+
+```typescript
+// Custom sprite template for your theme
+const customSpriteTemplate = `
+https://my-sprite-server.com/pokemon/
+{{#if isShiny}}shiny/{{/if}}
+{{species}}
+{{#if (isDefined form)}}
+    {{#if (not (isZero form))}}-form{{form}}{{/if}}
+{{/if}}
+{{addFemaleTag this "-female"}}
+.png
+`
+
+// Apply template
+V2.updateSpriteTemplate(customSpriteTemplate.replace(/\s+/g, ''))
+```
+
+### Error Handling and Fallbacks
+
+Implement robust error handling:
+
+```typescript
+export default createApp({
+    data() {
+        return {
+            errors: [],
+            retryCount: 0,
+            maxRetries: 3
+        }
+    },
+
+    methods: {
+        handleConnectionError() {
+            this.retryCount++
+
+            if (this.retryCount <= this.maxRetries) {
+                setTimeout(() => {
+                    V2.initialize()
+                }, 1000 * this.retryCount)
+            } else {
+                this.errors.push({
+                    type: 'connection',
+                    message: 'Failed to connect after multiple attempts'
+                })
+            }
+        },
+
+        handleSpriteError(event: Event, pokemon: Pokemon) {
+            const img = event.target as HTMLImageElement
+
+            // Try fallback sprite
+            if (img.src !== pokemon.fallbackSprite) {
+                V2.useFallback(img, pokemon)
+                return
+            }
+
+            // Use placeholder if fallback also fails
+            img.src = 'assets/images/placeholder-pokemon.png'
+
+            this.errors.push({
+                type: 'sprite',
+                message: `Failed to load sprite for ${pokemon.translations.english.speciesName}`,
+                pokemon: pokemon
+            })
+        }
+    }
+})
+```
+
+## Performance Optimization
+
+### Efficient Rendering
+
+```typescript
+// Use v-show instead of v-if for frequently toggled elements
+<div v-show="pokemon" class="pokemon-card">
+
+// Memoize expensive computations
+computed: {
+    sortedParty(): Pokemon[] {
+        return this.party
+            .filter(p => p !== null)
+            .sort((a, b) => a.level - b.level)
+    },
+
+    partyStats(): {totalLevel: number, averageLevel: number} {
+        const alive = this.sortedParty
+        const totalLevel = alive.reduce((sum, p) => sum + p.level, 0)
+
+        return {
+            totalLevel,
+            averageLevel: alive.length > 0 ? totalLevel / alive.length : 0
+        }
+    }
+}
+
+// Use object freeze for static data
+mounted() {
+    this.typeColors = Object.freeze({
+        'Fire': '#f08030',
+        'Water': '#6890f0',
+        // ... other types
+    })
+}
+```
+
+### Memory Management
+
+```typescript
+// Clean up resources
+beforeUnmount() {
+    // Remove event listeners if manually added
+    window.removeEventListener('resize', this.handleResize)
+
+    // Clear intervals/timeouts
+    if (this.animationInterval) {
+        clearInterval(this.animationInterval)
+    }
+
+    // Clear large data structures
+    this.spriteCache.clear()
+}
+```
+
+## Testing Your Theme
+
+### Development Testing
+
+1. **Use mock data:**
+```typescript
+if (clientSettings.params.getBool('mock', false)) {
+    this.party = mockPartyData
+    this.loaded = true
+}
+```
+
+2. **Test different scenarios:**
+- Empty party
+- Full party
+- Mixed levels
+- Different Pokemon types
+- Shiny Pokemon
+- Status conditions
+- Connection loss
+
+### URL Parameter Testing
+
+Test various URL configurations:
+
+```bash
+# Single slot display
+?user=TestUser&slot=1
+
+# Show HP bars
+?user=TestUser&hp=true
+
+# Debug mode
+?user=TestUser&debug=true
+
+# Multiple users
+?users=Player1,Player2
+
+# Custom sprite template
+?template=https://example.com/sprites/{{species}}.png
+```
+
+## Deployment and Distribution
+
+### Building for Production
+
+```bash
+# Build optimized version (recommended - uses Makefile)
+make build-prod
+
+# Or build with yarn
+yarn build
+
+# Test built version
+# Open index.html and verify all scripts load correctly
+```
+
+> 🚀 **Production Tip**: `make build-prod` sets NODE_ENV=production for optimized builds. Use `make clean` before production builds to ensure a clean state.
+
+### Theme Submission
+
+To share your theme with the community:
+
+1. **Create documentation:**
+   - Theme description
+   - Screenshot/preview
+   - Supported features
+   - URL parameters
+
+2. **Test thoroughly:**
+   - Multiple browsers
+   - Different screen sizes
+   - Various Pokemon combinations
+
+3. **Submit pull request:**
+   - Add to `themes.json`
+   - Include preview image
+   - Follow naming conventions
+
+This guide provides the foundation for creating custom PokeLink themes. Experiment with different layouts, animations, and features to create unique streaming experiences!

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -1,0 +1,221 @@
+# PokeLink Web V2 Makefile
+# Based on package.json scripts
+
+# Default target
+.DEFAULT_GOAL := help
+
+# Variables
+YARN := yarn
+TSC := $(YARN) tsc
+WEBPACK := $(YARN) webpack
+BUF := $(YARN) buf
+
+# Colors for output
+CYAN := \033[96m
+GREEN := \033[92m
+YELLOW := \033[93m
+RED := \033[91m
+NC := \033[0m # No Color
+
+# Help target
+.PHONY: help
+help: ## Show this help message
+	@echo "$(CYAN)PokeLink Web V2 Build System$(NC)"
+	@echo "Available targets:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(GREEN)%-20s$(NC) %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# Preparation
+.PHONY: prep
+prep: ## Install dependencies (yarn install)
+	@echo "$(YELLOW)Installing dependencies...$(NC)"
+	$(YARN) install
+	@echo "$(GREEN)Dependencies installed successfully$(NC)"
+
+# Protocol Buffer generation
+.PHONY: buf-generate
+buf-generate: ## Generate Protocol Buffer types
+	@echo "$(YELLOW)Generating Protocol Buffer types...$(NC)"
+	$(BUF) generate
+	@echo "$(GREEN)Protocol Buffer types generated$(NC)"
+
+# Core build targets
+.PHONY: build-core
+build-core: ## Build core TypeScript and webpack bundle
+	@echo "$(YELLOW)Building core libraries...$(NC)"
+	$(TSC) -p ./assets/tsconfig.json
+	$(WEBPACK) --config webpack.config.js
+	@echo "$(GREEN)Core build completed$(NC)"
+
+# Theme build targets
+.PHONY: build-themes-nodeps
+build-themes-nodeps: ## Build themes without dependencies
+	@echo "$(YELLOW)Building themes (no dependencies)...$(NC)"
+	$(TSC) -p ./themes/tsconfig.json
+	@echo "$(GREEN)Themes build completed$(NC)"
+
+.PHONY: build-themes
+build-themes: build-core build-themes-nodeps ## Build themes with dependencies
+	@echo "$(GREEN)Full themes build completed$(NC)"
+
+# Badge build targets
+.PHONY: build-badges-nodeps
+build-badges-nodeps: ## Build badges without dependencies
+	@echo "$(YELLOW)Building badges (no dependencies)...$(NC)"
+	$(TSC) -p ./badges/tsconfig.json
+	@echo "$(GREEN)Badges build completed$(NC)"
+
+.PHONY: build-badges
+build-badges: build-core build-badges-nodeps ## Build badges with dependencies
+	@echo "$(GREEN)Full badges build completed$(NC)"
+
+# Graveyard build targets
+.PHONY: build-graveyards-nodeps
+build-graveyards-nodeps: ## Build graveyards without dependencies
+	@echo "$(YELLOW)Building graveyards (no dependencies)...$(NC)"
+	$(TSC) -p ./graveyards/tsconfig.json
+	@echo "$(GREEN)Graveyards build completed$(NC)"
+
+.PHONY: build-graveyards
+build-graveyards: build-core build-graveyards-nodeps ## Build graveyards with dependencies
+	@echo "$(GREEN)Full graveyards build completed$(NC)"
+
+# Full build
+.PHONY: build
+build: prep buf-generate build-core build-themes-nodeps build-badges-nodeps build-graveyards-nodeps ## Complete build process
+	@echo "$(GREEN)Full build completed successfully!$(NC)"
+
+# Development targets
+.PHONY: build-watch
+build-watch: ## Build and watch for changes
+	@echo "$(YELLOW)Starting watch mode...$(NC)"
+	@echo "$(CYAN)Press Ctrl+C to stop$(NC)"
+	$(TSC) -p ./assets/tsconfig.json --watch &
+	$(TSC) -p ./themes/tsconfig.json --watch &
+	$(TSC) -p ./badges/tsconfig.json --watch &
+	$(TSC) -p ./graveyards/tsconfig.json --watch &
+	wait
+
+.PHONY: dev
+dev: build-core build-watch ## Development mode with core build and watch
+
+# Clean targets
+.PHONY: clean
+clean: ## Clean build artifacts
+	@echo "$(YELLOW)Cleaning build artifacts...$(NC)"
+	@rm -rf assets/dist/ themes/*/assets/js/*.js themes/*/assets/js/*.js.map
+	@rm -rf badges/*/assets/js/*.js badges/*/assets/js/*.js.map
+	@rm -rf graveyards/*/assets/js/*.js graveyards/*/assets/js/*.js.map
+	@echo "$(GREEN)Clean completed$(NC)"
+
+.PHONY: clean-deps
+clean-deps: clean ## Clean build artifacts and dependencies
+	@echo "$(YELLOW)Removing node_modules...$(NC)"
+	@rm -rf node_modules/
+	@echo "$(GREEN)Dependencies removed$(NC)"
+
+# Testing and validation
+.PHONY: check-types
+check-types: ## Type check all TypeScript files
+	@echo "$(YELLOW)Type checking...$(NC)"
+	$(TSC) -p ./assets/tsconfig.json --noEmit
+	$(TSC) -p ./themes/tsconfig.json --noEmit
+	$(TSC) -p ./badges/tsconfig.json --noEmit
+	$(TSC) -p ./graveyards/tsconfig.json --noEmit
+	@echo "$(GREEN)Type checking completed$(NC)"
+
+.PHONY: validate
+validate: check-types ## Validate project (type checking, etc.)
+	@echo "$(GREEN)Validation completed successfully$(NC)"
+
+# Individual component builds
+.PHONY: build-core-only
+build-core-only: build-core ## Build only core components
+
+.PHONY: build-themes-only
+build-themes-only: build-themes-nodeps ## Build only themes
+
+.PHONY: build-badges-only
+build-badges-only: build-badges-nodeps ## Build only badges
+
+.PHONY: build-graveyards-only
+build-graveyards-only: build-graveyards-nodeps ## Build only graveyards
+
+# Quick build (skip prep and buf generate)
+.PHONY: quick-build
+quick-build: build-core build-themes-nodeps build-badges-nodeps build-graveyards-nodeps ## Quick build without prep/buf generate
+	@echo "$(GREEN)Quick build completed$(NC)"
+
+# Production build
+.PHONY: build-prod
+build-prod: ## Production build with optimizations
+	@echo "$(YELLOW)Starting production build...$(NC)"
+	NODE_ENV=production $(MAKE) build
+	@echo "$(GREEN)Production build completed$(NC)"
+
+# Install and setup
+.PHONY: setup
+setup: prep buf-generate ## Initial project setup
+	@echo "$(GREEN)Project setup completed$(NC)"
+
+# Rebuild everything from scratch
+.PHONY: rebuild
+rebuild: clean build ## Clean and rebuild everything
+	@echo "$(GREEN)Rebuild completed$(NC)"
+
+# Show build info
+.PHONY: info
+info: ## Show build information
+	@echo "$(CYAN)PokeLink Web V2 Build Information$(NC)"
+	@echo "Node version: $$(node --version)"
+	@echo "Yarn version: $$($(YARN) --version)"
+	@echo "TypeScript version: $$($(TSC) --version)"
+	@echo "Project version: $$(grep '"version"' package.json | cut -d '"' -f 4)"
+	@echo ""
+	@echo "$(YELLOW)Available build targets:$(NC)"
+	@echo "  - Core libraries (TypeScript + Webpack)"
+	@echo "  - Themes (Vue.js components)"
+	@echo "  - Badges (Badge display components)"
+	@echo "  - Graveyards (Death tracking components)"
+
+# Lint and format (if tools are available)
+.PHONY: lint
+lint: ## Run linting (if available)
+	@if command -v eslint >/dev/null 2>&1; then \
+		echo "$(YELLOW)Running ESLint...$(NC)"; \
+		eslint . --ext .ts,.js,.vue; \
+	else \
+		echo "$(RED)ESLint not available$(NC)"; \
+	fi
+
+.PHONY: format
+format: ## Format code (if available)
+	@if command -v prettier >/dev/null 2>&1; then \
+		echo "$(YELLOW)Running Prettier...$(NC)"; \
+		prettier --write "**/*.{ts,js,vue,json,md}"; \
+	else \
+		echo "$(RED)Prettier not available$(NC)"; \
+	fi
+
+# Documentation
+.PHONY: docs
+docs: ## Build documentation (if available)
+	@echo "$(YELLOW)Documentation is available in the docs/ directory$(NC)"
+	@echo "Main documentation: ../docs/README.md"
+
+# Aliases for common tasks
+.PHONY: install
+install: prep ## Alias for prep
+
+.PHONY: compile
+compile: build ## Alias for build
+
+.PHONY: watch
+watch: build-watch ## Alias for build-watch
+
+# Error handling
+.PHONY: check-yarn
+check-yarn:
+	@command -v $(YARN) >/dev/null 2>&1 || { echo "$(RED)Error: Yarn is not installed$(NC)"; exit 1; }
+
+# All targets should check for yarn first
+prep build-core build-themes-nodeps build-badges-nodeps build-graveyards-nodeps buf-generate: check-yarn


### PR DESCRIPTION
Added a ton of documentation to make theme development way easier! 

This includes 9 new docs files covering everything from basic setup to advanced techniques. The biggest addition is a `Makefile` that makes building themes super simple - just run make setup to get started or make dev to code with auto-rebuilding. There's now complete guides for the API, data structures, Protocol Buffers, real code examples you can copy-paste, and troubleshooting help.

Basically turns this from "figure it out yourself" into "here's exactly how to build cool Pokemon streaming overlays" while keeping all the old stuff working perfectly.

Let me know what you think