### PR TITLE
Add shadow Pokémon heart gauge bar to themes with exp bars

### DIFF
--- a/v2/themes/_shared/components/heartGauge.vue.ts
+++ b/v2/themes/_shared/components/heartGauge.vue.ts
@@ -1,0 +1,25 @@
+import {defineComponent, PropType} from 'vue'
+import type {Pokemon} from 'v2Proto'
+
+export default defineComponent({
+    template: `
+      <div class="heart-gauge" v-if="!pokemon.isEgg && pokemon.isShadow">
+        <div
+            :style="{width: heartGaugeRemaining}"
+            class="heart-gauge__inner"
+        ></div>
+        <div class="heart-gauge__segments"></div>
+      </div>
+    `,
+    props: {
+        pokemon: {
+            type: Object as PropType<Pokemon>,
+            required: true
+        }
+    },
+    computed: {
+        heartGaugeRemaining(): string {
+            return `${this.pokemon.heartGaugePercentage ?? 0}%`
+        }
+    }
+})

--- a/v2/themes/bdsp-battle-style-hud/assets/css/styles.css
+++ b/v2/themes/bdsp-battle-style-hud/assets/css/styles.css
@@ -194,6 +194,40 @@
     border-radius: 2px;
 }
 
+.hp__text-and-exp .heart-gauge {
+    background-color: #e0e0e1;
+    height: 8px;
+    width: 195px;
+    right: 19px;
+    top: 10px;
+    position: absolute;
+    overflow: hidden;
+    border-radius: 2px;
+    padding: 1px;
+    padding-top: 2px;
+}
+
+.hp__text-and-exp .heart-gauge .heart-gauge__inner {
+    background-color: #7B2FBE;
+    height: 10px;
+    border-radius: 2px;
+    transition: width 2s;
+}
+
+.hp__text-and-exp .heart-gauge .heart-gauge__segments {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    background-image:
+        linear-gradient(to right, transparent calc(20% - 0.5px), rgba(255, 255, 255, 0.5) calc(20% - 0.5px), rgba(255, 255, 255, 0.5) calc(20% + 0.5px), transparent calc(20% + 0.5px),
+        transparent calc(40% - 0.5px), rgba(255, 255, 255, 0.5) calc(40% - 0.5px), rgba(255, 255, 255, 0.5) calc(40% + 0.5px), transparent calc(40% + 0.5px),
+        transparent calc(60% - 0.5px), rgba(255, 255, 255, 0.5) calc(60% - 0.5px), rgba(255, 255, 255, 0.5) calc(60% + 0.5px), transparent calc(60% + 0.5px),
+        transparent calc(80% - 0.5px), rgba(255, 255, 255, 0.5) calc(80% - 0.5px), rgba(255, 255, 255, 0.5) calc(80% + 0.5px), transparent calc(80% + 0.5px));
+}
+
 .pokemon .details span.lvl {
     position: absolute;
     right: 22px;

--- a/v2/themes/bdsp-battle-style-hud/assets/js/components/pokemon.vue.ts
+++ b/v2/themes/bdsp-battle-style-hud/assets/js/components/pokemon.vue.ts
@@ -30,7 +30,14 @@ export default defineComponent({
           <div class="hp__text-and-exp" v-if="!pokemon.isEgg">
             <span class="text">{{ pokemon.hp.current }}/{{ pokemon.hp.max }}</span>
 
-            <div class="exp" v-if="pokemonExists && !pokemon.isEgg && !hideLevel">
+            <div class="heart-gauge" v-if="pokemonExists && !pokemon.isEgg && !hideLevel && pokemon.isShadow">
+              <div
+                  :style="{width:heartGaugeRemaining}"
+                  class="heart-gauge__inner"
+              ></div>
+              <div class="heart-gauge__segments"></div>
+            </div>
+            <div class="exp" v-else-if="pokemonExists && !pokemon.isEgg && !hideLevel">
               <div
                   :style="{width:experienceRemaining}"
                   :class="{ exp__inner: true}"
@@ -129,6 +136,9 @@ export default defineComponent({
         },
         experienceRemaining() {
             return `${this.pokemon.expPercentage}%`
+        },
+        heartGaugeRemaining() {
+            return `${this.pokemon.heartGaugePercentage ?? 0}%`
         }
     },
     methods: {

--- a/v2/themes/bdsp-battle-style-hud/assets/js/components/pokemon.vue.ts
+++ b/v2/themes/bdsp-battle-style-hud/assets/js/components/pokemon.vue.ts
@@ -3,6 +3,7 @@ import {clientSettings, V2, V2DataTypes} from 'pokelink'
 import female from './female.vue.js'
 import male from './male.vue.js'
 import pokeball from './pokeball.vue.js'
+import heartGauge from '../../../../_shared/components/heartGauge.vue.js'
 import {Pokemon} from 'v2Proto'
 
 export default defineComponent({
@@ -30,14 +31,8 @@ export default defineComponent({
           <div class="hp__text-and-exp" v-if="!pokemon.isEgg">
             <span class="text">{{ pokemon.hp.current }}/{{ pokemon.hp.max }}</span>
 
-            <div class="heart-gauge" v-if="pokemonExists && !pokemon.isEgg && !hideLevel && pokemon.isShadow">
-              <div
-                  :style="{width:heartGaugeRemaining}"
-                  class="heart-gauge__inner"
-              ></div>
-              <div class="heart-gauge__segments"></div>
-            </div>
-            <div class="exp" v-else-if="pokemonExists && !pokemon.isEgg && !hideLevel">
+            <heart-gauge v-if="pokemonExists && !hideLevel" :pokemon="pokemon"></heart-gauge>
+            <div class="exp" v-if="pokemonExists && !pokemon.isEgg && !hideLevel && !pokemon.isShadow">
               <div
                   :style="{width:experienceRemaining}"
                   :class="{ exp__inner: true}"
@@ -62,7 +57,8 @@ export default defineComponent({
     components: {
         'female': female,
         'male': male,
-        'pokeball': pokeball
+        'pokeball': pokeball,
+        'heart-gauge': heartGauge
     },
     mounted() {
 
@@ -136,9 +132,6 @@ export default defineComponent({
         },
         experienceRemaining() {
             return `${this.pokemon.expPercentage}%`
-        },
-        heartGaugeRemaining() {
-            return `${this.pokemon.heartGaugePercentage ?? 0}%`
         }
     },
     methods: {

--- a/v2/themes/jezzabel-personal/assets/css/styles.css
+++ b/v2/themes/jezzabel-personal/assets/css/styles.css
@@ -203,6 +203,42 @@
     transition: width 2s;
 }
 
+.pokemon__list .pokemon .heart-gauge {
+    position: absolute;
+    bottom: 0px;
+    width: calc(100% - 160px);
+    height: 2px;
+    background: transparent;
+    z-index: 5;
+    right: 0;
+}
+
+.pokemon__list.flipped .pokemon .heart-gauge {
+    transform: scaleX(-1);
+    right: unset;
+    left: 0px;
+}
+
+.pokemon .heart-gauge .heart-gauge__inner {
+    background-color: #7B2FBE;
+    height: 3px;
+    transition: width 2s;
+}
+
+.pokemon .heart-gauge .heart-gauge__segments {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    background-image:
+        linear-gradient(to right, transparent calc(20% - 0.5px), rgba(255, 255, 255, 0.5) calc(20% - 0.5px), rgba(255, 255, 255, 0.5) calc(20% + 0.5px), transparent calc(20% + 0.5px),
+        transparent calc(40% - 0.5px), rgba(255, 255, 255, 0.5) calc(40% - 0.5px), rgba(255, 255, 255, 0.5) calc(40% + 0.5px), transparent calc(40% + 0.5px),
+        transparent calc(60% - 0.5px), rgba(255, 255, 255, 0.5) calc(60% - 0.5px), rgba(255, 255, 255, 0.5) calc(60% + 0.5px), transparent calc(60% + 0.5px),
+        transparent calc(80% - 0.5px), rgba(255, 255, 255, 0.5) calc(80% - 0.5px), rgba(255, 255, 255, 0.5) calc(80% + 0.5px), transparent calc(80% + 0.5px));
+}
+
 .pokemon__list .pokemon .pokemon__details {
     display: block;
 }

--- a/v2/themes/jezzabel-personal/assets/js/components/pokemon.vue.ts
+++ b/v2/themes/jezzabel-personal/assets/js/components/pokemon.vue.ts
@@ -40,7 +40,11 @@ export default defineComponent({
             {{ nickname }}
           </div>
 
-          <div class="exp" v-if="!pokemon.isEgg">
+          <div class="heart-gauge" v-if="!pokemon.isEgg && pokemon.isShadow">
+            <div :style="{width:heartGaugeRemaining}" class="heart-gauge__inner"></div>
+            <div class="heart-gauge__segments"></div>
+          </div>
+          <div class="exp" v-else-if="!pokemon.isEgg">
             <div :style="{width:experienceRemaining}" class="exp__inner"></div>
           </div>
         </div>
@@ -131,6 +135,12 @@ export default defineComponent({
                 return '0%'
             }
             return `${this.pokemon.expPercentage}%`
+        },
+        heartGaugeRemaining() {
+            if (!this.isValid) {
+                return '0%'
+            }
+            return `${this.pokemon.heartGaugePercentage ?? 0}%`
         },
         nameStyle() {
             let styles: {} = {

--- a/v2/themes/jezzabel-personal/assets/js/components/pokemon.vue.ts
+++ b/v2/themes/jezzabel-personal/assets/js/components/pokemon.vue.ts
@@ -3,6 +3,7 @@ import {V2, clientSettings, typeColors, V2DataTypes} from 'pokelink'
 import type {Pokemon} from 'v2Proto'
 import type {Nullable} from 'global'
 import trimmedSprite from '../../../../_shared/components/trimmedSprite.vue.js'
+import heartGauge from '../../../../_shared/components/heartGauge.vue.js'
 
 export default defineComponent({
     template: `
@@ -40,11 +41,8 @@ export default defineComponent({
             {{ nickname }}
           </div>
 
-          <div class="heart-gauge" v-if="!pokemon.isEgg && pokemon.isShadow">
-            <div :style="{width:heartGaugeRemaining}" class="heart-gauge__inner"></div>
-            <div class="heart-gauge__segments"></div>
-          </div>
-          <div class="exp" v-else-if="!pokemon.isEgg">
+          <heart-gauge :pokemon="pokemon"></heart-gauge>
+          <div class="exp" v-if="!pokemon.isEgg && !pokemon.isShadow">
             <div :style="{width:experienceRemaining}" class="exp__inner"></div>
           </div>
         </div>
@@ -52,7 +50,8 @@ export default defineComponent({
       </div>
     `,
     components: {
-        'trimmedSprite': trimmedSprite
+        'trimmedSprite': trimmedSprite,
+        'heart-gauge': heartGauge
     },
     props: {
         pokemon: {
@@ -135,12 +134,6 @@ export default defineComponent({
                 return '0%'
             }
             return `${this.pokemon.expPercentage}%`
-        },
-        heartGaugeRemaining() {
-            if (!this.isValid) {
-                return '0%'
-            }
-            return `${this.pokemon.heartGaugePercentage ?? 0}%`
         },
         nameStyle() {
             let styles: {} = {

--- a/v2/themes/stick-it-down/assets/css/styles.css
+++ b/v2/themes/stick-it-down/assets/css/styles.css
@@ -166,7 +166,34 @@
     height: 100%;
     align-self: flex-end;
     width: 12px;
+}
 
+.pokemon .heart-gauge {
+    height: 5px;
+    position: absolute;
+    width: 100%;
+    top: 0px;
+}
+
+.pokemon .heart-gauge .heart-gauge__inner {
+    background-color: #7B2FBE;
+    transition: width 2s;
+    height: 100%;
+    align-self: flex-end;
+}
+
+.pokemon .heart-gauge .heart-gauge__segments {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    background-image:
+        linear-gradient(to right, transparent calc(20% - 0.5px), rgba(255, 255, 255, 0.5) calc(20% - 0.5px), rgba(255, 255, 255, 0.5) calc(20% + 0.5px), transparent calc(20% + 0.5px),
+        transparent calc(40% - 0.5px), rgba(255, 255, 255, 0.5) calc(40% - 0.5px), rgba(255, 255, 255, 0.5) calc(40% + 0.5px), transparent calc(40% + 0.5px),
+        transparent calc(60% - 0.5px), rgba(255, 255, 255, 0.5) calc(60% - 0.5px), rgba(255, 255, 255, 0.5) calc(60% + 0.5px), transparent calc(60% + 0.5px),
+        transparent calc(80% - 0.5px), rgba(255, 255, 255, 0.5) calc(80% - 0.5px), rgba(255, 255, 255, 0.5) calc(80% + 0.5px), transparent calc(80% + 0.5px));
 }
 
 .pokemon__list .pokemon.isPoisoned .hp .hp__inner {

--- a/v2/themes/stick-it-down/assets/js/components/pokemon.vue.ts
+++ b/v2/themes/stick-it-down/assets/js/components/pokemon.vue.ts
@@ -2,6 +2,7 @@ import {defineComponent, PropType} from 'vue'
 import {clientSettings, Nullable, typeColors, V2, V2DataTypes} from 'pokelink'
 import type {Pokemon} from 'v2Proto'
 import trimmedSprite from '../../../../_shared/components/trimmedSprite.vue.js'
+import heartGauge from '../../../../_shared/components/heartGauge.vue.js'
 
 export default defineComponent({
     template: `
@@ -17,14 +18,8 @@ export default defineComponent({
           </div>
 
           <div class="pokemon__details">
-            <div class="heart-gauge" v-if="pokemonExists && !pokemon.isEgg && pokemon.isShadow">
-              <div
-                  :style="{width:heartGaugeRemaining}"
-                  class="heart-gauge__inner"
-              ></div>
-              <div class="heart-gauge__segments"></div>
-            </div>
-            <div class="exp" v-else-if="pokemonExists && !pokemon.isEgg">
+            <heart-gauge v-if="pokemonExists" :pokemon="pokemon"></heart-gauge>
+            <div class="exp" v-if="pokemonExists && !pokemon.isEgg && !pokemon.isShadow">
               <div
                   :style="{width:experienceRemaining}"
                   :class="{ exp__inner: true}"
@@ -47,7 +42,8 @@ export default defineComponent({
       </div>
     `,
     components: {
-        trimmedSprite: trimmedSprite
+        trimmedSprite: trimmedSprite,
+        'heart-gauge': heartGauge
     },
     props: {
         pokemon: {
@@ -116,9 +112,6 @@ export default defineComponent({
         },
         experienceRemaining () {
             return this.pokemon.expPercentage + '%'
-        },
-        heartGaugeRemaining() {
-            return `${this.pokemon.heartGaugePercentage ?? 0}%`
         },
         statusClasses () {
             if (typeof this.pokemon === "undefined") { return []; }

--- a/v2/themes/stick-it-down/assets/js/components/pokemon.vue.ts
+++ b/v2/themes/stick-it-down/assets/js/components/pokemon.vue.ts
@@ -17,7 +17,14 @@ export default defineComponent({
           </div>
 
           <div class="pokemon__details">
-            <div class="exp" v-if="pokemonExists && !pokemon.isEgg">
+            <div class="heart-gauge" v-if="pokemonExists && !pokemon.isEgg && pokemon.isShadow">
+              <div
+                  :style="{width:heartGaugeRemaining}"
+                  class="heart-gauge__inner"
+              ></div>
+              <div class="heart-gauge__segments"></div>
+            </div>
+            <div class="exp" v-else-if="pokemonExists && !pokemon.isEgg">
               <div
                   :style="{width:experienceRemaining}"
                   :class="{ exp__inner: true}"
@@ -109,6 +116,9 @@ export default defineComponent({
         },
         experienceRemaining () {
             return this.pokemon.expPercentage + '%'
+        },
+        heartGaugeRemaining() {
+            return `${this.pokemon.heartGaugePercentage ?? 0}%`
         },
         statusClasses () {
             if (typeof this.pokemon === "undefined") { return []; }

--- a/v2/themes/twitch-plays-pokemon/assets/css/styles.css
+++ b/v2/themes/twitch-plays-pokemon/assets/css/styles.css
@@ -184,6 +184,37 @@ img.sprite {
     transition: width 2s;
 }
 
+.heart-gauge {
+    right: 10px;
+    top: 45px;
+    z-index: 10;
+    position: absolute;
+    width: 365px;
+    height: 6px;
+    overflow: hidden;
+    background: #252525;
+}
+
+.heart-gauge .heart-gauge__inner {
+    height: 100%;
+    background-color: #7B2FBE;
+    transition: width 2s;
+}
+
+.heart-gauge .heart-gauge__segments {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    background-image:
+        linear-gradient(to right, transparent calc(20% - 0.5px), rgba(255, 255, 255, 0.5) calc(20% - 0.5px), rgba(255, 255, 255, 0.5) calc(20% + 0.5px), transparent calc(20% + 0.5px),
+        transparent calc(40% - 0.5px), rgba(255, 255, 255, 0.5) calc(40% - 0.5px), rgba(255, 255, 255, 0.5) calc(40% + 0.5px), transparent calc(40% + 0.5px),
+        transparent calc(60% - 0.5px), rgba(255, 255, 255, 0.5) calc(60% - 0.5px), rgba(255, 255, 255, 0.5) calc(60% + 0.5px), transparent calc(60% + 0.5px),
+        transparent calc(80% - 0.5px), rgba(255, 255, 255, 0.5) calc(80% - 0.5px), rgba(255, 255, 255, 0.5) calc(80% + 0.5px), transparent calc(80% + 0.5px));
+}
+
 .moves {
     right: 10px;
     position: absolute;

--- a/v2/themes/twitch-plays-pokemon/assets/js/components/pokemon.vue.ts
+++ b/v2/themes/twitch-plays-pokemon/assets/js/components/pokemon.vue.ts
@@ -1,17 +1,15 @@
 import {defineComponent, PropType} from 'vue'
 import type {Pokemon} from 'v2Proto'
 import {clientSettings, isDefined, V2, V2DataTypes} from 'pokelink'
+import heartGauge from '../../../../_shared/components/heartGauge.vue.js'
 
 export default defineComponent({
     template: `
     <div :class="{ 'pokemon': true, 'isDead': isDead}" :style="{'opacity': opacity }">
       <div v-if="isValid">
 
-        <div class="heart-gauge" v-if="!pokemon.isEgg && pokemon.isShadow">
-          <div :style="{width:heartGaugeRemaining}" class="heart-gauge__inner"></div>
-          <div class="heart-gauge__segments"></div>
-        </div>
-        <div class="exp" v-else-if="!pokemon.isEgg">
+        <heart-gauge :pokemon="pokemon"></heart-gauge>
+        <div class="exp" v-if="!pokemon.isEgg && !pokemon.isShadow">
           <div :style="{width:experienceRemaining}" class="exp__inner"></div>
         </div>
 
@@ -66,6 +64,9 @@ export default defineComponent({
       </div>
     </div>
   `,
+    components: {
+        'heart-gauge': heartGauge
+    },
     props: {
         pokemon: {
             type: Object as PropType<Pokemon>,
@@ -162,13 +163,6 @@ export default defineComponent({
             }
 
             return this.pokemon.expPercentage + '%'
-        },
-        heartGaugeRemaining () {
-            if (!this.isValid) {
-                return '0%'
-            }
-
-            return this.pokemon.heartGaugePercentage + '%'
         },
 
         selectedPokemon: {

--- a/v2/themes/twitch-plays-pokemon/assets/js/components/pokemon.vue.ts
+++ b/v2/themes/twitch-plays-pokemon/assets/js/components/pokemon.vue.ts
@@ -7,7 +7,11 @@ export default defineComponent({
     <div :class="{ 'pokemon': true, 'isDead': isDead}" :style="{'opacity': opacity }">
       <div v-if="isValid">
 
-        <div class="exp" v-if="!pokemon.isEgg">
+        <div class="heart-gauge" v-if="!pokemon.isEgg && pokemon.isShadow">
+          <div :style="{width:heartGaugeRemaining}" class="heart-gauge__inner"></div>
+          <div class="heart-gauge__segments"></div>
+        </div>
+        <div class="exp" v-else-if="!pokemon.isEgg">
           <div :style="{width:experienceRemaining}" class="exp__inner"></div>
         </div>
 
@@ -158,6 +162,13 @@ export default defineComponent({
             }
 
             return this.pokemon.expPercentage + '%'
+        },
+        heartGaugeRemaining () {
+            if (!this.isValid) {
+                return '0%'
+            }
+
+            return this.pokemon.heartGaugePercentage + '%'
         },
 
         selectedPokemon: {


### PR DESCRIPTION
For shadow Pokémon (isShadow=true), replace the exp bar with a purple heart gauge bar using heartGaugePercentage from the proto data. The bar
is segmented into 5 sections matching the in-game Colosseum/XD UI.

Notes:
Hidden for eggs, consistent #7B2FBE purple across all themes.

Themes updated: bdsp-battle-style-hud, stick-it-down,
twitch-plays-pokemon, jezzabel-personal.